### PR TITLE
feat: Excalidraw 0.18 — dark theme, in-editor editing, text/font fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "publish"
   ],
   "devDependencies": {
-    "@excalidraw/excalidraw": "0.17.2",
+    "@excalidraw/excalidraw": "0.18.1",
     "@types/markdown-it": "^12.2.3",
     "@types/node": "^14.0.14",
     "chalk": "^4.1.0",
@@ -25,8 +25,8 @@
     "fs-extra": "^9.0.1",
     "glob": "^7.1.6",
     "on-build-webpack": "^0.1.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-hot-toast": "^2.4.1",
     "tar": "^6.0.5",
     "ts-loader": "^7.0.5",

--- a/plugin.config.json
+++ b/plugin.config.json
@@ -1,5 +1,6 @@
 {
 	"extraScripts": [
-		"contentScripts/markdownIt.ts"
+		"contentScripts/markdownIt.ts",
+		"contentScripts/codeMirror.ts"
 	]
 }

--- a/src/contentScripts/codeMirror.ts
+++ b/src/contentScripts/codeMirror.ts
@@ -1,0 +1,38 @@
+// CodeMirror 6 helpers exposed to the plugin via `editor.execCommand`:
+//
+//  - excalidrawCurrentLine: text of the line the cursor is on, so
+//    "Edit Excalidraw drawing" can act on it without it being selected.
+//  - excalidrawRefreshImage: bust the cachebreaker on a drawing's <img> after
+//    it has been edited, so the editor's inline render reloads the new SVG
+//    instead of showing a stale/broken image until the note is reopened.
+//
+// Only the CodeMirror 6 (Markdown) editor is supported; elsewhere the commands
+// simply aren't registered and the plugin falls back gracefully.
+export default () => {
+  return {
+    plugin: (editorControl: any) => {
+      if (!editorControl || typeof editorControl.registerCommand !== 'function') return;
+
+      const editorView = () => editorControl.editor ?? editorControl.cm6 ?? editorControl.view;
+
+      editorControl.registerCommand('excalidrawCurrentLine', () => {
+        const state = editorView()?.state;
+        if (!state) return '';
+        return state.doc.lineAt(state.selection.main.head).text;
+      });
+
+      editorControl.registerCommand('excalidrawRefreshImage', (resourceId: string) => {
+        const id = Array.isArray(resourceId) ? resourceId[0] : resourceId;
+        if (!id) return;
+
+        const root: ParentNode = editorView()?.dom ?? document;
+        const images = root.querySelectorAll(`img[data-resource-id="${id}"], img[src*="${id}"]`);
+        images.forEach((image: any) => {
+          const src = image.getAttribute('src') || '';
+          const base = src.split('?')[0];
+          if (base) image.setAttribute('src', `${base}?t=${Date.now()}`);
+        });
+      });
+    },
+  };
+};

--- a/src/contentScripts/markdownIt-content.js
+++ b/src/contentScripts/markdownIt-content.js
@@ -1,0 +1,217 @@
+// Companion asset for the Excalidraw markdown-it content script (markdownIt.ts).
+//
+// Runs inside the Joplin Markdown viewer AND the Rich Text Editor. As of
+// laurent22/joplin#12106 (merged 2025-04-17) the Rich Text Editor enables a
+// Content-Security-Policy that blocks inline event handlers (onclick="...",
+// ondblclick="...", ...); the same PR started loading plugin assets in the Rich
+// Text Editor too. So instead of stringifying handlers into inline attributes
+// (which are silently killed by that CSP), we ship this asset and wire up all
+// interactions with addEventListener / DOM event properties, which the CSP allows.
+//
+// The markdown-it renderer only *tags* the Excalidraw images; this file finds
+// them and attaches the actions:
+//   - v2 drawings:        <img class="excalidraw--editable" ...>            -> "Edit"
+//   - legacy v1 diagrams: <img class="excalidraw--convertible"
+//                              data-excalidraw-diagram-id="..." ...>        -> "Convert to v2"
+//
+// NOTE: this file is intentionally plain JavaScript, not TypeScript. The webpack
+// "extraScripts" pipeline emits CommonJS modules (module.exports = ...), which is
+// invalid for a browser-injected asset; instead this file is copied verbatim into
+// dist/ by the copy-webpack-plugin. Keep it plain JS.
+
+(function () {
+	// Must match Config.ContentScriptId in src/index.ts.
+	var contentScriptId = 'excalidraw-script';
+
+	// webviewApi is injected by Joplin into the viewer / Rich Text Editor webview.
+	function getWebviewApi() {
+		try {
+			return typeof webviewApi !== 'undefined' ? webviewApi : null;
+		} catch (e) {
+			return null;
+		}
+	}
+
+	// Post a message to the plugin. Prefers webviewApi; falls back to the
+	// PluginService hack for older Joplin Rich Text Editor webviews that don't
+	// expose a webviewApi. Returns a Promise, or null if no channel is available.
+	function postMessage(message) {
+		var api = getWebviewApi();
+		if (api && typeof api.postMessage === 'function') {
+			return api.postMessage(contentScriptId, message);
+		}
+		try {
+			var PluginService = top.require('@joplin/lib/services/plugins/PluginService').default;
+			var service = PluginService.instance();
+			var pluginId = service.pluginIdByContentScriptId(contentScriptId);
+			return service.pluginById(pluginId).emitContentScriptMessage(contentScriptId, message);
+		} catch (e) {
+			return null;
+		}
+	}
+
+	// Give an edited drawing's <img> a fresh cachebreaker so the new SVG loads.
+	function bustCachebreaker(src) {
+		var base = src.split('?')[0];
+		return base + '?t=' + Date.now();
+	}
+
+	function resolveImage(arg) {
+		if (arg && arg.nodeType === 1) return arg;
+		return arg && arg.currentTarget ? arg.currentTarget : null;
+	}
+
+	// v2: open the editor for an existing drawing.
+	function onEdit(arg) {
+		var image = resolveImage(arg);
+		if (!image) return;
+		var message = encodeURIComponent(image.src);
+		var result = postMessage(message);
+		if (!result) return;
+		result
+			.then(function (resourceId) {
+				if (!resourceId) return;
+				var toRefresh = document.querySelectorAll('img[data-resource-id="' + resourceId + '"]');
+				Array.prototype.forEach.call(toRefresh, function (el) {
+					el.src = bustCachebreaker(el.src);
+				});
+			})
+			.catch(function (err) {
+				console.error('Error posting message for editing:', err, '\nMessage: ', message);
+			});
+	}
+
+	// v1: convert a legacy diagram to v2. The note update refreshes the preview.
+	function onConvert(arg) {
+		var image = resolveImage(arg);
+		if (!image) return;
+		var diagramId = image.getAttribute('data-excalidraw-diagram-id');
+		if (!diagramId) return;
+		var message = 'convert_v1_' + encodeURIComponent(diagramId);
+		var result = postMessage(message);
+		if (!result) return;
+		result
+			.then(function (svgResourceId) {
+				console.log('successfully converted v1', diagramId, 'into v2', svgResourceId);
+			})
+			.catch(function (err) {
+				console.error('Error posting message for conversion:', err, '\nMessage: ', message);
+			});
+	}
+
+	function isRichTextEditor() {
+		return document.body.classList.contains('mce-content-body') || document.body.id === 'tinymce';
+	}
+
+	// True for HTML notes and exported HTML, where an injected wrapper/button would
+	// be undesirable (always visible, or saved into the note).
+	function isHtmlNote() {
+		return !document.body.querySelector('#rendered-md');
+	}
+
+	function hasFocus(element) {
+		return element.contains(document.activeElement);
+	}
+
+	// Float a hover/focus button over the drawing's corner (Markdown viewer only).
+	// The image is NEVER wrapped or moved: it stays exactly where Joplin rendered
+	// it, so a right-click still lands on the <img> and Joplin's "Copy image"
+	// context-menu action keeps working. The button lives in a sibling container
+	// and is positioned over the image here in JS.
+	function addButton(image, label, handler) {
+		var next = image.nextElementSibling;
+		if (next && next.classList && next.classList.contains('excalidraw--editButtonContainer')) {
+			return;
+		}
+
+		var container = document.createElement('span');
+		container.className = 'excalidraw--editButtonContainer';
+
+		var button = document.createElement('button');
+		button.type = 'button';
+		button.className = 'excalidraw--editButton';
+		button.textContent = label;
+		container.appendChild(button);
+
+		image.insertAdjacentElement('afterend', container);
+		button.addEventListener('click', function () {
+			handler(image);
+		});
+
+		var pointers = new Set();
+		function updateVisible() {
+			var show =
+				pointers.size > 0 ||
+				button.matches(':hover, :focus') ||
+				hasFocus(button) ||
+				hasFocus(image);
+			container.classList.toggle('-show', show);
+		}
+		function updatePosition() {
+			var imageBox = image.getBoundingClientRect();
+			var containerBox = container.getBoundingClientRect();
+			button.style.right = imageBox.right - containerBox.right + 'px';
+			button.style.top = imageBox.top - containerBox.top + 'px';
+		}
+
+		image.addEventListener('pointerenter', function (event) {
+			pointers.add(event.pointerId);
+			updateVisible();
+			updatePosition();
+		});
+		image.addEventListener('pointerleave', function (event) {
+			pointers.delete(event.pointerId);
+			updateVisible();
+		});
+		[image, button].forEach(function (el) {
+			el.addEventListener('focus', function () {
+				updateVisible();
+				updatePosition();
+			});
+			el.addEventListener('blur', function () {
+				// Delay so tabbing image -> button doesn't flash the button away.
+				requestAnimationFrame(updateVisible);
+			});
+		});
+	}
+
+	function processImage(image, handler, label) {
+		// Already processed? Use the event-listener property as the marker: unlike a
+		// data-attribute or a class, the Rich Text Editor does not serialise it back
+		// into the note content.
+		if (image.ondblclick === handler) return;
+		image.ondblclick = handler;
+
+		if (isRichTextEditor() || isHtmlNote()) {
+			// Don't inject a button here: in the Rich Text Editor the extra DOM is
+			// saved into the note; in HTML notes it would always be visible.
+			// Double-click still edits.
+			image.style.cursor = 'pointer';
+		} else if (getWebviewApi()) {
+			addButton(image, label, handler);
+		}
+	}
+
+	function processImages() {
+		if (!document.body) return;
+
+		var editable = document.querySelectorAll('img.excalidraw--editable');
+		Array.prototype.forEach.call(editable, function (image) {
+			processImage(image, onEdit, 'Edit 🖊️');
+		});
+
+		var convertible = document.querySelectorAll('img.excalidraw--convertible');
+		Array.prototype.forEach.call(convertible, function (image) {
+			processImage(image, onConvert, 'Convert to v2 🔄');
+		});
+	}
+
+	// Joplin re-fires this when the rendered note changes.
+	document.addEventListener('joplin-noteDidUpdate', processImages);
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', processImages);
+	} else {
+		processImages();
+	}
+})();

--- a/src/contentScripts/markdownIt.css
+++ b/src/contentScripts/markdownIt.css
@@ -1,27 +1,31 @@
 /* Reference: https://github.com/personalizedrefrigerator/joplin-plugin-freehand-drawing/blob/main/src/contentScripts/markdownIt.css */
-.excalidraw--editButton {
-	display: none;
-	width: min-content;
-	max-height: 50px;
+
+/*
+ * The Edit / Convert button floats over the drawing's corner. It sits in a
+ * container that is a *sibling* of the <img> -- the image itself is never
+ * wrapped or moved, so a right-click still lands on the <img> and Joplin's
+ * "Copy image" context-menu action keeps working. The button is positioned
+ * over the image in markdownIt-content.js.
+ */
+.excalidraw--editButtonContainer {
+	display: inline-block;
+	position: relative;
+	opacity: 0;
+	overflow: hidden;
 	z-index: 1;
+	transition: opacity 0.2s ease;
+}
+
+.excalidraw--editButtonContainer.-show,
+.excalidraw--editButtonContainer:hover,
+.excalidraw--editButtonContainer:focus-within {
 	opacity: 0.9;
-
-	align-self: flex-end;
-	justify-self: right;
+	overflow: visible;
 }
 
-.excalidraw--svgWrapper {
-	display: inline-grid;
-}
-
-.excalidraw--svgWrapper > * {
-	grid-row: 1;
-	grid-column: 1;
-}
-
-.excalidraw--svgWrapper:hover .excalidraw--editButton,
-.excalidraw--svgWrapper:focus .excalidraw--editButton,
-.excalidraw--svgWrapper:focus-within .excalidraw--editButton,
-.excalidraw--editButton:focus {
-	display: block;
+.excalidraw--editButton {
+	position: absolute;
+	width: max-content;
+	max-height: 50px;
+	white-space: nowrap;
 }

--- a/src/contentScripts/markdownIt.ts
+++ b/src/contentScripts/markdownIt.ts
@@ -3,235 +3,30 @@ import type MarkdownIt = require('markdown-it');
 import type Renderer = require('markdown-it/lib/renderer');
 import type Token = require('markdown-it/lib/token');
 
-declare const webviewApi: any;
-
-// We need to pass 'contentScriptId' (always with value 'excalidraw-script') as an argument because we're converting
-// editImage to a string.
-const editImage = (contentScriptId: string, container: HTMLElement, svgElemId: string) => {
-	// Don't declare as a toplevel constant -- function is stringified.
-	const debug = false;
-
-	const imageElem = container.querySelector('img') ?? document.querySelector(`img#${svgElemId}`);
-
-	if (!imageElem?.src) {
-		throw new Error(`${imageElem} lacks an src attribute. Unable to edit!`);
-	}
-
-	const updateCachebreaker = (initialSrc: string) => {
-		// Strip the ?t=... at the end of the image URL
-		const cachebreakerMatch = /^(.*)\?t=(\d+)$/.exec(initialSrc);
-		const fileUrl = cachebreakerMatch ? cachebreakerMatch[1] : initialSrc;
-
-		const oldCachebreaker = cachebreakerMatch ? parseInt(cachebreakerMatch[2]) : 0;
-		const newCachebreaker = new Date().getTime();
-
-		// Add the cachebreaker to the global list -- we may need to change cachebreakers
-		// on future rerenders.
-		(window as any)['outOfDateCacheBreakers'] ??= {};
-		(window as any)['outOfDateCacheBreakers'][fileUrl] = {
-			outdated: oldCachebreaker,
-			suggested: newCachebreaker,
-		};
-
-		return `${fileUrl}?t=${newCachebreaker}`;
-	};
-
-	// all remaining images must be with the new format (SVG resource id)
-	const svgResourceId = imageElem.src;
-	const message = encodeURIComponent(svgResourceId);
-	const imageElemClass = `imageelem-${new Date().getTime()}`;
-	imageElem.classList.add(imageElemClass);
-
-	// The webview api is different if we're running in the TinyMce editor vs if we're running
-	// in the preview pane.
-	try {
-		let postMessage;
-
-		try {
-			postMessage = webviewApi.postMessage;
-		} catch (error) {
-			// Don't log by default
-			if (debug) {
-				console.error('Unable to access webviewApi.postMessage: ', error);
-			}
-		}
-
-		if (!postMessage) {
-			// TODO:
-			//  This is a hack to workaround the lack of a webviewApi in the rich text editor
-			//  webview.
-			//  As top.require **should not work** at some point in the future, this will fail.
-			const PluginService = (top! as any).require(
-				'@joplin/lib/services/plugins/PluginService',
-			).default;
-
-			postMessage = (contentScriptId: string, message: string) => {
-				const pluginService = PluginService.instance();
-				const pluginId = pluginService.pluginIdByContentScriptId(contentScriptId);
-				return pluginService
-					.pluginById(pluginId)
-					.emitContentScriptMessage(contentScriptId, message);
-			};
-		}
-
-		postMessage(contentScriptId, message)
-			.then((resourceId: string | null) => {
-				// Update matching images
-				const toRefresh = document.querySelectorAll(`
-					img[data-resource-id="${resourceId}"]
-				`);
-
-				for (const elem of toRefresh) {
-					const imageElem = elem as HTMLImageElement;
-					imageElem.src = updateCachebreaker(imageElem.src);
-				}
-			})
-			.catch((err: any) => {
-				console.error('Error posting message for editing:', err, '\nMessage: ', message);
-			});
-	} catch (err) {
-		console.error('Failed posting message for editing:', err);
-	}
-};
-
-// Warning: this function will be stringified
-const convertDiagram = (contentScriptId: string, container: HTMLElement, svgId: string, diagramId: string) => {
-	// Don't declare as a toplevel constant -- function is stringified.
-	const debug = false;
-
-	// craft a special message to request conversion
-	const message = "convert_v1_" + encodeURIComponent(diagramId);
-
-	// The webview api is different if we're running in the TinyMce editor vs if we're running
-	// in the preview pane.
-	try {
-		let postMessage;
-
-		try {
-			postMessage = webviewApi.postMessage;
-		} catch (error) {
-			// Don't log by default
-			if (debug) {
-				console.error('Unable to access webviewApi.postMessage: ', error);
-			}
-		}
-
-		if (!postMessage) {
-			// TODO:
-			//  This is a hack to workaround the lack of a webviewApi in the rich text editor
-			//  webview.
-			//  As top.require **should not work** at some point in the future, this will fail.
-			const PluginService = (top! as any).require(
-				'@joplin/lib/services/plugins/PluginService',
-			).default;
-
-			postMessage = (contentScriptId: string, message: string) => {
-				const pluginService = PluginService.instance();
-				const pluginId = pluginService.pluginIdByContentScriptId(contentScriptId);
-				return pluginService
-					.pluginById(pluginId)
-					.emitContentScriptMessage(contentScriptId, message);
-			};
-		}
-
-		postMessage(contentScriptId, message)
-			.then((svgResourceId: string | null) => {
-				// nothing else to do here, the note update will take care of updating the image preview as well
-				console.log("successfully converted v1", diagramId,"into v2", svgResourceId);
-			})
-			.catch((err: any) => {
-				console.error('Error posting message for conversion:', err, '\nMessage: ', message);
-			});
-	} catch (err) {
-		console.error('Failed posting message for conversion:', err);
-	}
-};
-
-const onImgLoad = (container: HTMLElement, buttonId: string, refresh: boolean) => {
-	let button = container.querySelector('button.excalidraw--editButton');
-	const imageElem = container.querySelector('img');
-
-	if (!imageElem) {
-		throw new Error('excalidraw editor: Unable to find an image in the given container!');
-	}
-
-	// Another plugin may have moved the button
-	if (!button) {
-		button = document.querySelector(`#${buttonId}`);
-
-		// In the rich text editor, an image might be reloading when the button has already
-		// been removed:
-		if (!button) {
-			return;
-		}
-
-		button.remove();
-		container.appendChild(button);
-	}
-	container.classList.add('excalidraw--svgWrapper');
-
-	if (refresh) {
-		const outOfDateCacheBreakers = (window as any)['outOfDateCacheBreakers'] ?? {};
-		const imageSrcMatch = /^(.*)\?t=(\d+)$/.exec(imageElem.src);
-
-		if (!imageSrcMatch) {
-			throw new Error(`${imageElem?.src} doesn't have a cachebreaker! Unable to update it.`);
-		}
-
-		const fileUrl = imageSrcMatch[1];
-		const cachebreaker = parseInt(imageSrcMatch[2] ?? '0');
-		const badCachebreaker = outOfDateCacheBreakers[fileUrl] ?? {};
-
-		if (isNaN(cachebreaker) || cachebreaker <= badCachebreaker?.outdated) {
-			imageElem.src = `${fileUrl}?t=${badCachebreaker.suggested}`;
-		}
-	}
-
-	let haveWebviewApi = true;
-	try {
-		// Attempt to access .postMessage
-		// Note: We can't just check window.webviewApi because webviewApi seems not to be
-		//       a property on window.
-		haveWebviewApi = typeof webviewApi.postMessage === 'function';
-	} catch (_err) {
-		haveWebviewApi = false;
-	}
-
-	if (!haveWebviewApi) {
-		console.warn(
-			"The webview library either doesn't exist or lacks a postMessage function. Unable to display an edit button.",
-		);
-		button?.remove();
-	}
-};
+// The interactive "Edit" / "Convert to v2" buttons are attached at view time by
+// the companion asset (markdownIt-content.js) using addEventListener -- NOT via
+// inline on* handlers, which the Rich Text Editor's Content-Security-Policy
+// blocks (laurent22/joplin#12106). This renderer therefore only *tags* the
+// Excalidraw images so that asset can find them, and swaps in a placeholder logo
+// for legacy v1 diagrams (whose excalidraw:// URI can't be loaded as an image).
 
 function getTagValue(token: any, tagName: string): string | null {
-    if (token.attrs && token.attrs.length > 0) {
-        for (const attr of token.attrs) {
-            if (attr[0] === tagName) {
-                return attr[1]
-            }
-        }
-    }
-    return null
+	if (token.attrs && token.attrs.length > 0) {
+		for (const attr of token.attrs) {
+			if (attr[0] === tagName) {
+				return attr[1];
+			}
+		}
+	}
+	return null;
 }
 
-const excalidrawLogo = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAARQAAABZCAYAAAD/wdt/AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAABEBSURBVHhe7Z2/axvZFsf9Z0yRYgVuAimSzuo2gi0i2GIFKdYQWCNeYUSKRbgIIrAEkcKILYJ5RRBeWJCLBblYUIqAskVALgJysaAUC3KRQg9STOFChYvz7hnNlc7cuXd+Xo0t7fnAYbPSaDQazf3e7zn3jLwDDMMwlmBBYRjGGiwoDMNYgwWFYRhrsKAwDGMNFhSGYazBgsIwjDVYUBiGsUYhgvLTTz/BN9984/336urKf5RhmG1jrYLy119/eUKys7OzjHv37rGoMMyWsjZBQTGhQkKDRYVhtpO1CAqmNlRA0KX89ttvAbfCosIw24d1Qfn2228DYoL/L0EBUVMgFhWG2R6sCooqJr/88ov/zAqdqKB7YRhm87EiKCgSqphgDcWETlR04sMwzGaRW1BUccB/q2KCDgSDpjcsKgyzfeQSFBQFKgi0XiKhzgUFhEWFYbaXzIKiLgvrxEQVHAxVMFhUGGZ7yCwoVABQEHRgmkO3wzAJjyoqXKhlmM0js6BQATANfl1zW5RQ0PSIBYVhNo/MgkIHP62LqKCo4LbY7Ba38iP3Z3I8DMPcbTILCu2GjRKKpGDdRO5PV0PB94gSLmYzmbtz/1/MNpBZUGh9JK+gxLkT6YZ09Rdmc5l/aIEjvlfnWQ+m/mPMZmNFUPLWO6LcSZxzYTaX2Vlt+d22L/wHmY0ms6CgK5EXQx5BiXIn9DkMZrtgQdk+co1SeTFgPSUr7E7+vbCgbB+5BEUuHWetbcTVTuT+Mbggu31QQamdzfxHC+DLAJqPS3D/xzYM+LKyihVBwchCUneSxwExd5fbEpTp28ryfXee9qBAKdt6cgkKXTpO6yDYnTC3IyhzGB4t3nMRbRj5zzD5ySUo1EWkXTqOcie04KsTG2Y7oILS+NP1H103U+h+t3jPRbCg2MSaQ0mz0pPGneRdkmbuLjT1KKwoOx9C03/PRbCg2MRaDSVNnWMr3MnNHNyrMQzf9eDkuAOd4y70P4xgMnOFqWaSMHolB3WBgnLVg5r/notowpC/MGtYcyhJV3qoO8FQoSKlis2t83UCw7M21B/f9zo86eeg4XzfgfG1/xrGyG0IivtnI/Bd7ezUoPfFf5LJTS5Bod2yGEmKp1SE7qQ7uRYO48b/t/Aa7gxFpAONJ6XlsSUJ58WQnUoMK0FxoP3Jf9DHfd+G6q54brcGJ5f2zuT4tRP4nlhQ7JJLUBDHWX1BcYXZO+1O5mM4eZpONCKDlyNjWQmKMqjnQ2g55Fw6+9C3Muhn0H9G9qt7byYXuQVF3riHEScCUdtSd4JR+FLxFzW31sRuGepHXehfTGCmu0v2Zgq9Z77AsqDEYhQUdwANet5FOM+6MMmdRs6g9zS4X66h2CW3oNC0J+qPd8UJBnUnt5LuGAWlBNXDE+hfzhKmMC5MsDj71f9fxohRUATTP5uLlId8F87hQJzdPIygTfa3CF7lsUluQVHTGF3ao24T504KT3cQzaxYft6DMQvDmqANZoZBfTOD0Vkb9h/4rs9pw9h/KhsaQWEnaZXcgoJQd4FFVxmY4tDnZES5Ewx8bfGIC/wFKdj9wL/RsV5o+lGUS9AISm7Xw1ByC4rqLuJCXV7WvT7pErRtaOfm5s9cc5hdDqF/ij0yIt70YCDStrvD3RCU6mnEtHE9hcFpE+rfVeC+LBLvlqHytAGt08GWpbXis/5c8dohSi9HmVcocwmKmsokiTh3IuM2CAjKq4SXODa4zSYw+jCEYSDGMI35ecP55y40DzswzFJ/Fu87vRxA700Hmgc16Fys3mv2oQM1pf4go3Rgo7hpAzK4v+sW4wZnfdgn5yJyhed6DJ3v1SVmNUpQezO+HYczn8H4XQ96H2xMElPoH5AVzmf9zJNprpGLtQ55EJimoNuggeJBBQP/TaGvV0MVniJIKijzq7GY+cXMFdPghv0V1V/HerXHmo2c9Zx96CX9uF/Fe7/aX82YMrzjncPo9WKWCTynxp5wBGlGgbh4R2cn0DqsQUXM1hj1o4Xz6b6bZhxQRFBsucG5K0TWF/RLcVzqiVcL7wd9w7GT1boE4TxuwSDmA7ifB9A9Xrgd7xyiy/Gd4yjlh59ftKGy/P4d2P8jz9kT18yrMvk8+faXS1CoWOgEQBUMFBkKfT1dUsa4dUE5OFlcmMvW+o4YUNXwQI6Nfejrvh/14haDfBxlaMSgHh7XoERfI2O3Dt3P/4PhC3phRIfzPFntwH3fIhevPpykbo5C76nJKyg3pnNTgvrpZCXoyjk33ZA4/jV8Hp0HvhD4UVYdoFOB1nvN/q4n0KWzvzbS9cLQDmMvRIqSlfnHFjwi+3qUI91BrDkUFARZhKVCISPOnahuRhWfIgh9UQmjtFeB2mFrUasg4uNd4CahoA7Fj7IYmLpNp+dN7aAuPWlC9wKXs9VZBqME1aMuDD/PwHWnwh53obFHn4/rv5jD5O1+tNtxSlDyjktY/+MhzJYdxgmgg9soKFMYvqpD5bBvTolc4XQCn0sNMuMqgqJt9//ahzrZZmenDO2POuGZw+xCpKyPqZOpQvcf/2nk6xBakccmvsPdhdg4j5vQ+zuJxGua87IK8rUQdXpdoXPNmQ7nEhQc9IEPFhHqXcP0OVmEpS6leEHRNT0ZwrkP+9jgprPVlBsc6mbQupYD+xYX/xkZOq5+dis9bYv3Xl18eH9KYOCL2VI3CPD9VrNR1KwYTp2cx3U4OR/C+MoVAiU/VfCcpbrdgA5u0wwrjlfuW+smruPExA9ZE7jsBGZjnaAEXKqIskhZo3Fhct4WqUxZTCBEUK6EMAVcjBDdVz0YeE2R4hzKE0U+Y0iQtKi/5yIiU81DSevSpN0R5K5+otOQzkQenOpQkrgTBOsw8rHif7ZgDJ2Hq2MKhS8ig8927yaenqkuoAytd1OYagqrOIuhIwmiHreYUUmBNsgUuk/87ZyW0aEEj2lRB9LPneqqSZIB4fNPFyrydaaUiQy2ylvVo8xh/DroytRaxhydGaatn9DFudA/WG2L0frob0gYvSTbPBQzdpYvWxW6vQb0DYNVFbAkohx8jQOtD+orFnfCj40qo567qGsmHbkFRUI7ZlXBoOKA4kGfk+4EofsoXlDUweHHbg067ybgprHzKZn+HpNaRK0mKLNu7Iw6G3u1IePFJvZHXZMpDfOgouCHc5TQpdCZ2SQo9LOpLkZJX8rPB+a0CFHOE0a49qO4VNNxReLC4DDpzK9xGwlEOSgowdQVO4yX6bHTgIFmaVt1xvEuLDlrERTVrUhUocGgxVdVlAol8MM7/pd0TazpWtHVQPwwpC+S2R/7ZHtDATgxwVk87g9wTd9WyXvLSOhSkggKFQ1laXl6St57rxPTQUucGQ1H7X8ZQ5vWFLIISkC4YmZ+tYbhR5woBwQl0ICpHD/u67VyZq56sE+2sf1H1qwJiqmeQoWB1kgwqDtB6D4K75alP7xTVF8EIVQH8eKRsOXRihacrXI2iNHbDxwhqlEFui/9wIVJI9E9N9TdmAZQQOTFbLvcKboA+fgO1M+j300vfBiPoHPpb+ShuNQMgjL+9dHy9dVQmkYJp2yrKCvHFSTwnZOCrLpi4wUVnFAqlr8Iq7JWQVFrJ7RGgqFbGpbPqWKzduiMaasvIiHuR7U4u4rIlEMQ/MGgqrgQowUokiR1DQ+1T8MBJyAu8UKYbJUnOMBXNQ+amkQvuYbsvfhcw+PVoH8UsPt5BYWmMOmOyyE/A+KFOCcmOdIKiuI8VtFaTDLqapilIqzKWgVFTVvocybBkOlS0YISGJg/dGGidr8u+1FIc5IIXV8KLiN7jUtv+rFdqdOzur63hERcHaNKtxcXSvdzRlH51F65pIeGNELTV4EzsasMkJ29FgyjWtMj0pkVQrh+WO1zNfiTCQoOWrrcvrT3VDjp51Q7aVMLSnBJ1+ScQr096AbdsEjvvyU9NISQoMSsdmEPTbBvxoHm+xwTTwRrExTVnajPm4qutP5SJMHUwV6EclgJNmO9rgbTnL0G9C5nMLvsKkuOQlQO8CcUdMvUShHQC+wLwXtNUl40yh3X5RcDmPm7wBUTvPNXXXmiYhdasfIa7gzHECiq+rNoCFORlD6uGxwuTM4aQYF7KN5jKe60pkJWSZRCrzEVi4CmPJ64y+X9mznMPg/g5D9KJzN1CiFhcKDychhKHwOTn1OFWuwtAjTMQmUDa6NWXb1R3QkVCgyToNC0SJcSrYusTW3acO77Dqau+fnCude3EFoSVn9AyNgUpZmR8UIMNFitAmen+tEJ9N4tekhWP2+pR9clqg9xsb9WnZOm9d/UQRoQr4qxkEu/l5VDUVdHylA/7sEAneT5CdTVc6Gx9+55ffW8bMFXBSViad3I13DDojGE4IaWk0P9K8LxqvdfaVbXZHjX0T994zHEpdB5sSYoVAji3AnGXROUwF+TiwtPMGrQeClSoNO+lxKNvI7UuK9qCoPn4QFr/DUyww1q2j+KdTOFvn+3qLq9GpiS4b043XPNr/QbVh4CIUSieW7K8HUrVg7c/7EDo0AKFFx5qfx34j8ehDpH+rkDghAVYtDqawXi3C4F21+ZSnPzYATmIvAqSk9PYKzPiPT1kN0qNP+Y+t+VftWKrtiE+5t0E4B9rAhKWneCYRIUunSMQlQYy1WLMlSUGc55UIUGzoCYcsTURCKhhV8ZsZV2F0bHq5sBsbltEHGRu3/3oJnyB7UfqbPW1cCwD2zn78HENBCWaJyKZjk5sLJlcgPLGV9dkYm/gS9y0Armn1Z1n0V7vpI+Psm62jeH8RvNDZwinAf70Elyh7DGqdCmN7WoWxIuSz1W92PHq/fVDjuBzup1YkVQUEDkB0viTjCSCIppm7Uxd33BcGF6kSxFSIVqqeMKl3nw/uTHCTQP9IXjQBgGzlzsQxam0YGlPhezIXSxkG28o1YMvN9b0Hhah+bpKFQrWILHcSFnZwK6siP/nqllCDf0fQNOEt7W7wnwgXBPUtQx1fQmFAvdo95PTMjCfvzPWYTBtv4T794w3V3d7qfFQkH2O77tk1tQ0rgT2odiEgsqQOq+Nh8yA+41Cv3L/3N3cWt//xQHsBQZTEWiZ/HNYC7STZtNiLg/azv7V5FbUKg7waBQcUBhof8f5T7kNoU3txUCup/xcvWEYbaJXIKSxp3gc0kFRb6u8OY2hmFykUtQotwJfU7WVdIKinwdwzCbQS5BkeKAEeVOpHgkFRS6dMwwzOaQecSq7oT2jOjcCZJFUIrsRWEYJh+ZBYU6kCh3giIiSSoo+Jzu9QzD3G0yCYpajDW5E7WomlRQkm7HMMzdIpOgRImGfBxDTVdYUBhmu8kkKHKwY5jciZoGITSViRMKud129qIwzHaSWlBoukPdCX3ctNybRlBkHYZ7URhmc8glKGncCZJGUFBIcDsWFIbZHDKlPJiGUEFI4k6QNLUR7kVhmM3DymhN4k4QKij47yjoPqkTYhjm7mJFUGS9I8qdSO7du5dIJOQ+WVAYZnOwIihSJDCiHIokTiBk/QQjiUgxDHM3sCIotN6RVFRM0H2xmDDMZmFFUNBx0BQlq6jQuglGXJ2FYZi7hRVBkdBUBSONqNAlZQwWE4bZPKwKCqJLf+JqJnT1B4PFhGE2E+uCgqipS5SosJgwzPawFkFBUETo6g+mQ6qoqGIS1+zGMMzdZm2CgqBgmESFxYRhto+1CgqCwkFXgPb29kIpEYsJw2wHaxcURLeszGLCMNtHIYIiUVeAWEwYZrsoVFAQFBGspfBqDsNsH4ULCsMw2wsLCsMw1mBBYRjGGiwoDMNYgwWFYRhrsKAwDGMJgP8Dgo5+g9Lpn8IAAAAASUVORK5CYII=`
+const excalidrawLogo = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAARQAAABZCAYAAAD/wdt/AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAABEBSURBVHhe7Z2/axvZFsf9Z0yRYgVuAimSzuo2gi0i2GIFKdYQWCNeYUSKRbgIIrAEkcKILYJ5RRBeWJCLBblYUIqAskVALgJysaAUC3KRQg9STOFChYvz7hnNlc7cuXd+Xo0t7fnAYbPSaDQazf3e7zn3jLwDDMMwlmBBYRjGGiwoDMNYgwWFYRhrsKAwDGMNFhSGYazBgsIwjDVYUBiGsUYhgvLTTz/BN9984/336urKf5RhmG1jrYLy119/eUKys7OzjHv37rGoMMyWsjZBQTGhQkKDRYVhtpO1CAqmNlRA0KX89ttvAbfCosIw24d1Qfn2228DYoL/L0EBUVMgFhWG2R6sCooqJr/88ov/zAqdqKB7YRhm87EiKCgSqphgDcWETlR04sMwzGaRW1BUccB/q2KCDgSDpjcsKgyzfeQSFBQFKgi0XiKhzgUFhEWFYbaXzIKiLgvrxEQVHAxVMFhUGGZ7yCwoVABQEHRgmkO3wzAJjyoqXKhlmM0js6BQATANfl1zW5RQ0PSIBYVhNo/MgkIHP62LqKCo4LbY7Ba38iP3Z3I8DMPcbTILCu2GjRKKpGDdRO5PV0PB94gSLmYzmbtz/1/MNpBZUGh9JK+gxLkT6YZ09Rdmc5l/aIEjvlfnWQ+m/mPMZmNFUPLWO6LcSZxzYTaX2Vlt+d22L/wHmY0ms6CgK5EXQx5BiXIn9DkMZrtgQdk+co1SeTFgPSUr7E7+vbCgbB+5BEUuHWetbcTVTuT+Mbggu31QQamdzfxHC+DLAJqPS3D/xzYM+LKyihVBwchCUneSxwExd5fbEpTp28ryfXee9qBAKdt6cgkKXTpO6yDYnTC3IyhzGB4t3nMRbRj5zzD5ySUo1EWkXTqOcie04KsTG2Y7oILS+NP1H103U+h+t3jPRbCg2MSaQ0mz0pPGneRdkmbuLjT1KKwoOx9C03/PRbCg2MRaDSVNnWMr3MnNHNyrMQzf9eDkuAOd4y70P4xgMnOFqWaSMHolB3WBgnLVg5r/notowpC/MGtYcyhJV3qoO8FQoSKlis2t83UCw7M21B/f9zo86eeg4XzfgfG1/xrGyG0IivtnI/Bd7ezUoPfFf5LJTS5Bod2yGEmKp1SE7qQ7uRYO48b/t/Aa7gxFpAONJ6XlsSUJ58WQnUoMK0FxoP3Jf9DHfd+G6q54brcGJ5f2zuT4tRP4nlhQ7JJLUBDHWX1BcYXZO+1O5mM4eZpONCKDlyNjWQmKMqjnQ2g55Fw6+9C3Muhn0H9G9qt7byYXuQVF3riHEScCUdtSd4JR+FLxFzW31sRuGepHXehfTGCmu0v2Zgq9Z77AsqDEYhQUdwANet5FOM+6MMmdRs6g9zS4X66h2CW3oNC0J+qPd8UJBnUnt5LuGAWlBNXDE+hfzhKmMC5MsDj71f9fxohRUATTP5uLlId8F87hQJzdPIygTfa3CF7lsUluQVHTGF3ao24T504KT3cQzaxYft6DMQvDmqANZoZBfTOD0Vkb9h/4rs9pw9h/KhsaQWEnaZXcgoJQd4FFVxmY4tDnZES5Ewx8bfGIC/wFKdj9wL/RsV5o+lGUS9AISm7Xw1ByC4rqLuJCXV7WvT7pErRtaOfm5s9cc5hdDqF/ij0yIt70YCDStrvD3RCU6mnEtHE9hcFpE+rfVeC+LBLvlqHytAGt08GWpbXis/5c8dohSi9HmVcocwmKmsokiTh3IuM2CAjKq4SXODa4zSYw+jCEYSDGMI35ecP55y40DzswzFJ/Fu87vRxA700Hmgc16Fys3mv2oQM1pf4go3Rgo7hpAzK4v+sW4wZnfdgn5yJyhed6DJ3v1SVmNUpQezO+HYczn8H4XQ96H2xMElPoH5AVzmf9zJNprpGLtQ55EJimoNuggeJBBQP/TaGvV0MVniJIKijzq7GY+cXMFdPghv0V1V/HerXHmo2c9Zx96CX9uF/Fe7/aX82YMrzjncPo9WKWCTynxp5wBGlGgbh4R2cn0DqsQUXM1hj1o4Xz6b6bZhxQRFBsucG5K0TWF/RLcVzqiVcL7wd9w7GT1boE4TxuwSDmA7ifB9A9Xrgd7xyiy/Gd4yjlh59ftKGy/P4d2P8jz9kT18yrMvk8+faXS1CoWOgEQBUMFBkKfT1dUsa4dUE5OFlcmMvW+o4YUNXwQI6Nfejrvh/14haDfBxlaMSgHh7XoERfI2O3Dt3P/4PhC3phRIfzPFntwH3fIhevPpykbo5C76nJKyg3pnNTgvrpZCXoyjk33ZA4/jV8Hp0HvhD4UVYdoFOB1nvN/q4n0KWzvzbS9cLQDmMvRIqSlfnHFjwi+3qUI91BrDkUFARZhKVCISPOnahuRhWfIgh9UQmjtFeB2mFrUasg4uNd4CahoA7Fj7IYmLpNp+dN7aAuPWlC9wKXs9VZBqME1aMuDD/PwHWnwh53obFHn4/rv5jD5O1+tNtxSlDyjktY/+MhzJYdxgmgg9soKFMYvqpD5bBvTolc4XQCn0sNMuMqgqJt9//ahzrZZmenDO2POuGZw+xCpKyPqZOpQvcf/2nk6xBakccmvsPdhdg4j5vQ+zuJxGua87IK8rUQdXpdoXPNmQ7nEhQc9IEPFhHqXcP0OVmEpS6leEHRNT0ZwrkP+9jgprPVlBsc6mbQupYD+xYX/xkZOq5+dis9bYv3Xl18eH9KYOCL2VI3CPD9VrNR1KwYTp2cx3U4OR/C+MoVAiU/VfCcpbrdgA5u0wwrjlfuW+smruPExA9ZE7jsBGZjnaAEXKqIskhZo3Fhct4WqUxZTCBEUK6EMAVcjBDdVz0YeE2R4hzKE0U+Y0iQtKi/5yIiU81DSevSpN0R5K5+otOQzkQenOpQkrgTBOsw8rHif7ZgDJ2Hq2MKhS8ig8927yaenqkuoAytd1OYagqrOIuhIwmiHreYUUmBNsgUuk/87ZyW0aEEj2lRB9LPneqqSZIB4fNPFyrydaaUiQy2ylvVo8xh/DroytRaxhydGaatn9DFudA/WG2L0frob0gYvSTbPBQzdpYvWxW6vQb0DYNVFbAkohx8jQOtD+orFnfCj40qo567qGsmHbkFRUI7ZlXBoOKA4kGfk+4EofsoXlDUweHHbg067ybgprHzKZn+HpNaRK0mKLNu7Iw6G3u1IePFJvZHXZMpDfOgouCHc5TQpdCZ2SQo9LOpLkZJX8rPB+a0CFHOE0a49qO4VNNxReLC4DDpzK9xGwlEOSgowdQVO4yX6bHTgIFmaVt1xvEuLDlrERTVrUhUocGgxVdVlAol8MM7/pd0TazpWtHVQPwwpC+S2R/7ZHtDATgxwVk87g9wTd9WyXvLSOhSkggKFQ1laXl6St57rxPTQUucGQ1H7X8ZQ5vWFLIISkC4YmZ+tYbhR5woBwQl0ICpHD/u67VyZq56sE+2sf1H1qwJiqmeQoWB1kgwqDtB6D4K75alP7xTVF8EIVQH8eKRsOXRihacrXI2iNHbDxwhqlEFui/9wIVJI9E9N9TdmAZQQOTFbLvcKboA+fgO1M+j300vfBiPoHPpb+ShuNQMgjL+9dHy9dVQmkYJp2yrKCvHFSTwnZOCrLpi4wUVnFAqlr8Iq7JWQVFrJ7RGgqFbGpbPqWKzduiMaasvIiHuR7U4u4rIlEMQ/MGgqrgQowUokiR1DQ+1T8MBJyAu8UKYbJUnOMBXNQ+amkQvuYbsvfhcw+PVoH8UsPt5BYWmMOmOyyE/A+KFOCcmOdIKiuI8VtFaTDLqapilIqzKWgVFTVvocybBkOlS0YISGJg/dGGidr8u+1FIc5IIXV8KLiN7jUtv+rFdqdOzur63hERcHaNKtxcXSvdzRlH51F65pIeGNELTV4EzsasMkJ29FgyjWtMj0pkVQrh+WO1zNfiTCQoOWrrcvrT3VDjp51Q7aVMLSnBJ1+ScQr096AbdsEjvvyU9NISQoMSsdmEPTbBvxoHm+xwTTwRrExTVnajPm4qutP5SJMHUwV6EclgJNmO9rgbTnL0G9C5nMLvsKkuOQlQO8CcUdMvUShHQC+wLwXtNUl40yh3X5RcDmPm7wBUTvPNXXXmiYhdasfIa7gzHECiq+rNoCFORlD6uGxwuTM4aQYF7KN5jKe60pkJWSZRCrzEVi4CmPJ64y+X9mznMPg/g5D9KJzN1CiFhcKDychhKHwOTn1OFWuwtAjTMQmUDa6NWXb1R3QkVCgyToNC0SJcSrYusTW3acO77Dqau+fnCude3EFoSVn9AyNgUpZmR8UIMNFitAmen+tEJ9N4tekhWP2+pR9clqg9xsb9WnZOm9d/UQRoQr4qxkEu/l5VDUVdHylA/7sEAneT5CdTVc6Gx9+55ffW8bMFXBSViad3I13DDojGE4IaWk0P9K8LxqvdfaVbXZHjX0T994zHEpdB5sSYoVAji3AnGXROUwF+TiwtPMGrQeClSoNO+lxKNvI7UuK9qCoPn4QFr/DUyww1q2j+KdTOFvn+3qLq9GpiS4b043XPNr/QbVh4CIUSieW7K8HUrVg7c/7EDo0AKFFx5qfx34j8ehDpH+rkDghAVYtDqawXi3C4F21+ZSnPzYATmIvAqSk9PYKzPiPT1kN0qNP+Y+t+VftWKrtiE+5t0E4B9rAhKWneCYRIUunSMQlQYy1WLMlSUGc55UIUGzoCYcsTURCKhhV8ZsZV2F0bHq5sBsbltEHGRu3/3oJnyB7UfqbPW1cCwD2zn78HENBCWaJyKZjk5sLJlcgPLGV9dkYm/gS9y0Armn1Z1n0V7vpI+Psm62jeH8RvNDZwinAf70Elyh7DGqdCmN7WoWxIuSz1W92PHq/fVDjuBzup1YkVQUEDkB0viTjCSCIppm7Uxd33BcGF6kSxFSIVqqeMKl3nw/uTHCTQP9IXjQBgGzlzsQxam0YGlPhezIXSxkG28o1YMvN9b0Hhah+bpKFQrWILHcSFnZwK6siP/nqllCDf0fQNOEt7W7wnwgXBPUtQx1fQmFAvdo95PTMjCfvzPWYTBtv4T794w3V3d7qfFQkH2O77tk1tQ0rgT2odiEgsqQOq+Nh8yA+41Cv3L/3N3cWt//xQHsBQZTEWiZ/HNYC7STZtNiLg/azv7V5FbUKg7waBQcUBhof8f5T7kNoU3txUCup/xcvWEYbaJXIKSxp3gc0kFRb6u8OY2hmFykUtQotwJfU7WVdIKinwdwzCbQS5BkeKAEeVOpHgkFRS6dMwwzOaQecSq7oT2jOjcCZJFUIrsRWEYJh+ZBYU6kCh3giIiSSoo+Jzu9QzD3G0yCYpajDW5E7WomlRQkm7HMMzdIpOgRImGfBxDTVdYUBhmu8kkKHKwY5jciZoGITSViRMKud129qIwzHaSWlBoukPdCX3ctNybRlBkHYZ7URhmc8glKGncCZJGUFBIcDsWFIbZHDKlPJiGUEFI4k6QNLUR7kVhmM3DymhN4k4QKij47yjoPqkTYhjm7mJFUGS9I8qdSO7du5dIJOQ+WVAYZnOwIihSJDCiHIokTiBk/QQjiUgxDHM3sCIotN6RVFRM0H2xmDDMZmFFUNBx0BQlq6jQuglGXJ2FYZi7hRVBkdBUBSONqNAlZQwWE4bZPKwKCqJLf+JqJnT1B4PFhGE2E+uCgqipS5SosJgwzPawFkFBUETo6g+mQ6qoqGIS1+zGMMzdZm2CgqBgmESFxYRhto+1CgqCwkFXgPb29kIpEYsJw2wHaxcURLeszGLCMNtHIYIiUVeAWEwYZrsoVFAQFBGspfBqDsNsH4ULCsMw2wsLCsMw1mBBYRjGGiwoDMNYgwWFYRhrsKAwDGMJgP8Dgo5+g9Lpn8IAAAAASUVORK5CYII=`;
 
 export default (context: { contentScriptId: string }) => {
 	return {
 		plugin: (markdownIt: MarkdownIt, _options: any) => {
-			const editSvgCommandIdentifier = context.contentScriptId;
-			let idCounter = 0;
-
-			const editImageFnString = editImage.toString().replace(/["]/g, '&quot;');
-			const onImgLoadFnString = onImgLoad.toString().replace(/["]/g, '&quot;');
-
-			// used to convert v1 diagram resources
-			const convertDiagramFnString = convertDiagram.toString().replace(/["]/g, '&quot;');
-
 			// Ref: https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer
-			// and the joplin-drawio plugin
 			const originalRenderer = markdownIt.renderer.rules.image;
 			markdownIt.renderer.rules.image = (
 				tokens: Token[],
@@ -241,65 +36,51 @@ export default (context: { contentScriptId: string }) => {
 				self: Renderer,
 			): string => {
 				let defaultHtml = originalRenderer?.(tokens, idx, options, env, self) ?? '';
-
-				const buttonId = `excalidraw-edit-button-${idCounter}`;
-				const svgElemId = `excalidraw-editable-svg-${idCounter}`;
-				idCounter++;
-
-				let actionCallbackJs = null, label = null, refresh = true;
-
-				// check if it's a v1 resource
 				const token = tokens[idx];
+
+				// Legacy v1 diagram: ![excalidraw](excalidraw://<id>)
 				if (token.content == 'excalidraw') {
-        			const diagramId = getTagValue(token, "src").substring("excalidraw://".length);
-					if (diagramId === null) {
+					const src = getTagValue(token, 'src');
+					if (!src) {
 						// malformed
 						return defaultHtml;
 					}
-
-					// replace image URI with the excalidraw logo data URI (assets don't work)
-					// no cache breaker is used on this
-					defaultHtml = defaultHtml.replace("excalidraw://"+diagramId, excalidrawLogo);
-
-					actionCallbackJs = `(${convertDiagramFnString})('${editSvgCommandIdentifier}', this.parentElement, '${svgElemId}', '${diagramId}')`;
-					label = "Convert to v2 🔄";
-					refresh = false;
-				} else if (token.content == 'excalidraw.svg') {
-					const svgUrlExp =
-						/src\s*=\s*['"](file:[/][/]|jop[-a-zA-Z]+:[/][/])?[^'"]*[.]svg([?]t=\d+)?['"]/i;
-					if (!svgUrlExp.exec(defaultHtml ?? '')) {
-						console.warn("found a v2 resource, the URL is unrecognised");
+					const diagramId = src.substring('excalidraw://'.length);
+					if (!diagramId) {
 						return defaultHtml;
 					}
 
-					// example: 'excalidraw-script', this.parentElement, 'excalidraw-editable-svg-0'
-					actionCallbackJs = `(${editImageFnString})('${editSvgCommandIdentifier}', this.parentElement, '${svgElemId}')`;
-					label = "Edit 🖊️";
-					refresh = true;
-				} else
-					// not a special token
-					return defaultHtml;
+					// The excalidraw:// URI can't be loaded as an image (assets don't
+					// work), so show the Excalidraw logo as a placeholder. No cache
+					// breaker is used on this one.
+					defaultHtml = defaultHtml.replace('excalidraw://' + diagramId, excalidrawLogo);
 
-				const htmlWithOnload = defaultHtml.replace(
-					'<img ',
-					`<img id="${svgElemId}" ondblclick="${actionCallbackJs}" onload="(${onImgLoadFnString})(this.parentElement, '${buttonId}', ${refresh})" `,
-				);
+					// Tag for the asset, which offers a "Convert to v2" action.
+					return defaultHtml.replace(
+						'<img ',
+						`<img class="excalidraw--convertible" data-excalidraw-diagram-id="${diagramId}" `,
+					);
+				}
 
-				return `
-				<span class='excalidraw--svgWrapper' contentEditable='false'>
-					${htmlWithOnload}
-					<button
-						class='excalidraw--editButton'
-						onclick="${actionCallbackJs}"
-						id="${buttonId}">
-						${label}
-					</button>
-				</span>
-				`;
+				// v2 drawing: ![excalidraw.svg](:/<id>)
+				if (token.content == 'excalidraw.svg') {
+					const svgUrlExp =
+						/src\s*=\s*['"](file:[/][/]|jop[-a-zA-Z]+:[/][/])?[^'"]*[.]svg([?]t=\d+)?['"]/i;
+					if (!svgUrlExp.exec(defaultHtml ?? '')) {
+						console.warn('found a v2 resource, the URL is unrecognised');
+						return defaultHtml;
+					}
+
+					// Tag for the asset, which offers an "Edit" action.
+					return defaultHtml.replace('<img ', '<img class="excalidraw--editable" ');
+				}
+
+				// Not an Excalidraw image.
+				return defaultHtml;
 			};
 		},
 		assets: () => {
-			return [{ name: 'markdownIt.css' }];
+			return [{ name: 'markdownIt.css' }, { name: 'markdownIt-content.js' }];
 		},
 	};
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,15 @@
 import joplin from 'api'
 import { v4 as uuidv4 } from 'uuid';
 
-import { ContentScriptType, MenuItemLocation, ToolbarButtonLocation } from 'api/types'
+import { ContentScriptType, MenuItemLocation, SettingItemType, ToolbarButtonLocation } from 'api/types'
 import { createDiagramResource, getDiagramResource, updateDiagramResource, clearDiskCache, duplicateV1DiagramAsV2, generateId } from './resources';
 
 const Config = {
   ContentScriptId: 'excalidraw-script',
+  CodeMirrorScriptId: 'excalidraw-codemirror',
+  SettingsSection: 'excalidraw',
+  NewThemeSetting: 'newDrawingTheme',
+  PreserveThemeSetting: 'preserveDrawingTheme',
 }
 
 type JoplinThemePref = 'light' | 'dark' | 'auto';
@@ -28,15 +32,63 @@ const joplinThemePref = async (): Promise<JoplinThemePref> => {
   return 'auto';
 }
 
+const registerSettings = async (): Promise<void> => {
+  await joplin.settings.registerSection(Config.SettingsSection, {
+    label: 'Excalidraw',
+    iconName: 'fas fa-pencil-alt',
+  });
+
+  await joplin.settings.registerSettings({
+    [Config.NewThemeSetting]: {
+      value: 'joplin',
+      type: SettingItemType.String,
+      section: Config.SettingsSection,
+      public: true,
+      isEnum: true,
+      options: { joplin: 'Follow Joplin theme', light: 'Light', dark: 'Dark' },
+      label: 'Theme for new drawings',
+    },
+    [Config.PreserveThemeSetting]: {
+      value: true,
+      type: SettingItemType.Bool,
+      section: Config.SettingsSection,
+      public: true,
+      label: "Keep each drawing's saved theme",
+      description: 'When off, existing drawings also open using the "Theme for new drawings" setting.',
+    },
+  });
+}
+
+// Theme to open a NEW drawing with: an explicit Light/Dark choice, otherwise
+// whatever Joplin is currently using.
+const newDrawingThemePref = async (): Promise<JoplinThemePref> => {
+  try {
+    const setting = await joplin.settings.value(Config.NewThemeSetting);
+    if (setting === 'light' || setting === 'dark') return setting;
+  } catch (error) {
+    console.warn('excalidraw: could not read the theme setting:', error);
+  }
+  return joplinThemePref();
+}
+
+const preserveDrawingTheme = async (): Promise<boolean> => {
+  try {
+    return (await joplin.settings.value(Config.PreserveThemeSetting)) !== false;
+  } catch (error) {
+    return true;
+  }
+}
+
 const escapeAttribute = (value: string): string =>
   value.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
 
-const buildDialogHTML = (diagramBody: string, theme: JoplinThemePref): string => {
+const buildDialogHTML = (diagramBody: string, theme: JoplinThemePref, preserveTheme: boolean): string => {
   return `
 		<form name="main" style="display:none">
 			<input type="hidden" name="excalidraw_diagram_json" id="excalidraw_diagram_json" value="${escapeAttribute(diagramBody)}">
 			<input type="hidden" name="excalidraw_diagram_svg" id="excalidraw_diagram_svg" value="">
 			<input type="hidden" name="excalidraw_theme" id="excalidraw_theme" value="${theme}">
+			<input type="hidden" name="excalidraw_preserve_theme" id="excalidraw_preserve_theme" value="${preserveTheme}">
 		</form>
 		`
 }
@@ -48,7 +100,8 @@ function diagramMarkdown(diagramId: string) {
 const openDialog = async (svgResourceId: string = null): Promise<string | null> => {
   let diagramBody = "{}";
   const appPath = await joplin.plugins.installationDir();
-  const theme = await joplinThemePref();
+  const theme = await newDrawingThemePref();
+  const preserveTheme = await preserveDrawingTheme();
 
   const isNewDiagram = (svgResourceId === null);
   if (!isNewDiagram) {
@@ -59,7 +112,7 @@ const openDialog = async (svgResourceId: string = null): Promise<string | null> 
   let dialogs = joplin.views.dialogs;
   let dialogHandle = await dialogs.create(`excalidraw-dialog-${uuidv4()}`);
 
-  let header = buildDialogHTML(diagramBody, theme);
+  let header = buildDialogHTML(diagramBody, theme, preserveTheme);
   let iframe = `<iframe id="excalidraw_iframe" style="position:absolute;border:0;width:100%;height:100%;" src="${appPath}/local-excalidraw/index.html" title="Excalidraw frame"></iframe>`
 
   await dialogs.setHtml(dialogHandle, header + iframe);
@@ -81,10 +134,26 @@ const openDialog = async (svgResourceId: string = null): Promise<string | null> 
       let diagramJson = dialogResult.formData.main.excalidraw_diagram_json;
       let diagramSvg = dialogResult.formData.main.excalidraw_diagram_svg;
       await updateDiagramResource(svgResourceId, diagramJson, diagramSvg)
+      await refreshDrawingImage(svgResourceId);
     }
   }
 
   return svgResourceId;
+}
+
+// After updating the resource the already-rendered <img> still points at the
+// old content, and Joplin won't reload a note that's open in the editor. Bust
+// the image's cachebreaker (via the CodeMirror content script) so the new SVG
+// appears in the editor's inline render without reopening the note.
+const refreshDrawingImage = async (svgResourceId: string): Promise<void> => {
+  try {
+    await joplin.commands.execute('editor.execCommand', {
+      name: 'excalidrawRefreshImage',
+      args: [svgResourceId],
+    });
+  } catch (error) {
+    console.warn('excalidraw: could not refresh the drawing image:', error);
+  }
 }
 
 // Resource ids of v2 Excalidraw drawings (![excalidraw.svg](:/id)) in some text.
@@ -96,10 +165,23 @@ const excalidrawSvgIds = (text: string): string[] => {
   return ids;
 }
 
-// Resolve which drawing the "Edit Excalidraw drawing" command should open,
-// using the current selection first and the whole note as a fallback. This is
-// editor-agnostic (works in both the Markdown and rich text editors).
+// Text of the editor's current line, via the CodeMirror content script.
+const editorCurrentLine = async (): Promise<string> => {
+  try {
+    const line = await joplin.commands.execute('editor.execCommand', { name: 'excalidrawCurrentLine' });
+    return typeof line === 'string' ? line : '';
+  } catch (error) {
+    return '';
+  }
+}
+
+// Resolve which drawing the "Edit Excalidraw drawing" command should open: the
+// drawing on the cursor's current line first, then the selection, then the
+// note's only drawing.
 const findExcalidrawForEditing = async (): Promise<string | null> => {
+  const onLine = excalidrawSvgIds(await editorCurrentLine());
+  if (onLine.length >= 1) return onLine[0];
+
   const selection = await joplin.commands.execute('selectedText').catch(() => '');
   const inSelection = excalidrawSvgIds(typeof selection === 'string' ? selection : '');
   if (inSelection.length === 1) return inSelection[0];
@@ -111,7 +193,7 @@ const findExcalidrawForEditing = async (): Promise<string | null> => {
   await joplin.views.dialogs.showMessageBox(
     inNote.length === 0
       ? 'No Excalidraw drawing was found in this note.'
-      : 'This note has several Excalidraw drawings. Select the one you want to edit, then run the command again.'
+      : 'Put the cursor on the line of the Excalidraw drawing you want to edit, then run the command again.'
   );
   return null;
 }
@@ -120,6 +202,7 @@ joplin.plugins.register({
   onStart: async () => {
 
     clearDiskCache();
+    await registerSettings();
 
     const installDir = await joplin.plugins.installationDir();
     const excalidrawCssFilePath = installDir + '/excalidraw.css';
@@ -130,6 +213,14 @@ joplin.plugins.register({
       ContentScriptType.MarkdownItPlugin,
       Config.ContentScriptId,
       './contentScripts/markdownIt.js',
+    );
+
+    // exposes the editor's current line, so "Edit Excalidraw drawing" can act on
+    // the line the cursor is on without it having to be selected
+    await joplin.contentScripts.register(
+      ContentScriptType.CodeMirrorPlugin,
+      Config.CodeMirrorScriptId,
+      './contentScripts/codeMirror.js',
     );
 
     // this is the main message processing function
@@ -203,10 +294,22 @@ joplin.plugins.register({
 
     await joplin.views.toolbarButtons.create('addExcalidraw', 'addExcalidraw', ToolbarButtonLocation.EditorToolbar);
 
-    // Allow editing a drawing straight from the editor, not just from the
-    // preview pane's edit button.
-    await joplin.views.menuItems.create('editExcalidrawContextMenu', 'editExcalidraw', MenuItemLocation.EditorContextMenu);
-    await joplin.views.menuItems.create('addExcalidrawToolsMenu', 'addExcalidraw', MenuItemLocation.Tools);
-    await joplin.views.menuItems.create('editExcalidrawToolsMenu', 'editExcalidraw', MenuItemLocation.Tools);
+    // Group both commands under a single Tools > Excalidraw submenu.
+    await joplin.views.menus.create('excalidrawMenu', 'Excalidraw', [
+      { commandName: 'addExcalidraw' },
+      { commandName: 'editExcalidraw' },
+    ], MenuItemLocation.Tools);
+
+    // Offer "Edit Excalidraw drawing" in the editor's right-click menu, but only
+    // when the cursor's current line actually holds a drawing.
+    joplin.workspace.filterEditorContextMenu(async (contextMenu: any) => {
+      if (excalidrawSvgIds(await editorCurrentLine()).length > 0) {
+        contextMenu.items.push(
+          { type: 'separator' },
+          { commandName: 'editExcalidraw', label: 'Edit Excalidraw drawing' },
+        );
+      }
+      return contextMenu;
+    });
   },
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import joplin from 'api'
 import { v4 as uuidv4 } from 'uuid';
 
-import { ContentScriptType, ToolbarButtonLocation } from 'api/types'
+import { ContentScriptType, MenuItemLocation, ToolbarButtonLocation } from 'api/types'
 import { createDiagramResource, getDiagramResource, updateDiagramResource, clearDiskCache, duplicateV1DiagramAsV2, generateId } from './resources';
 
 const Config = {
@@ -87,6 +87,35 @@ const openDialog = async (svgResourceId: string = null): Promise<string | null> 
   return svgResourceId;
 }
 
+// Resource ids of v2 Excalidraw drawings (![excalidraw.svg](:/id)) in some text.
+const excalidrawSvgIds = (text: string): string[] => {
+  const ids: string[] = [];
+  const regex = /!\[excalidraw\.svg\]\(:\/([a-zA-Z0-9]+)\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text ?? '')) !== null) ids.push(match[1]);
+  return ids;
+}
+
+// Resolve which drawing the "Edit Excalidraw drawing" command should open,
+// using the current selection first and the whole note as a fallback. This is
+// editor-agnostic (works in both the Markdown and rich text editors).
+const findExcalidrawForEditing = async (): Promise<string | null> => {
+  const selection = await joplin.commands.execute('selectedText').catch(() => '');
+  const inSelection = excalidrawSvgIds(typeof selection === 'string' ? selection : '');
+  if (inSelection.length === 1) return inSelection[0];
+
+  const note = await joplin.workspace.selectedNote();
+  const inNote = excalidrawSvgIds(note?.body ?? '');
+  if (inNote.length === 1) return inNote[0];
+
+  await joplin.views.dialogs.showMessageBox(
+    inNote.length === 0
+      ? 'No Excalidraw drawing was found in this note.'
+      : 'This note has several Excalidraw drawings. Select the one you want to edit, then run the command again.'
+  );
+  return null;
+}
+
 joplin.plugins.register({
   onStart: async () => {
 
@@ -154,7 +183,7 @@ joplin.plugins.register({
 
     await joplin.commands.register({
       name: 'addExcalidraw',
-      label: 'add excalidraw panel',
+      label: 'Add Excalidraw drawing',
       iconName: 'icon-excalidraw-plus-icon-filled',
       execute: async () => {
         // return as promise
@@ -162,6 +191,22 @@ joplin.plugins.register({
       }
     });
 
+    await joplin.commands.register({
+      name: 'editExcalidraw',
+      label: 'Edit Excalidraw drawing',
+      iconName: 'icon-excalidraw-plus-icon-filled',
+      execute: async () => {
+        const svgResourceId = await findExcalidrawForEditing();
+        return svgResourceId ? openDialog(svgResourceId) : null;
+      }
+    });
+
     await joplin.views.toolbarButtons.create('addExcalidraw', 'addExcalidraw', ToolbarButtonLocation.EditorToolbar);
+
+    // Allow editing a drawing straight from the editor, not just from the
+    // preview pane's edit button.
+    await joplin.views.menuItems.create('editExcalidrawContextMenu', 'editExcalidraw', MenuItemLocation.EditorContextMenu);
+    await joplin.views.menuItems.create('addExcalidrawToolsMenu', 'addExcalidraw', MenuItemLocation.Tools);
+    await joplin.views.menuItems.create('editExcalidrawToolsMenu', 'editExcalidraw', MenuItemLocation.Tools);
   },
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,11 +8,35 @@ const Config = {
   ContentScriptId: 'excalidraw-script',
 }
 
-const buildDialogHTML = (diagramBody: string): string => {
+type JoplinThemePref = 'light' | 'dark' | 'auto';
+
+// Joplin's built-in dark theme ids (see @joplin/lib/theme). Known light ids are
+// resolved directly; anything unknown (e.g. auto-detect, custom themes) is left
+// to the editor, which detects light/dark from the dialog's actual colours.
+const DARK_THEME_IDS = new Set([2, 4, 5, 6, 7, 22]);
+const LIGHT_THEME_IDS = new Set([1, 3]);
+
+const joplinThemePref = async (): Promise<JoplinThemePref> => {
+  try {
+    if (await joplin.settings.globalValue('themeAutoDetect')) return 'auto';
+    const themeId = Number(await joplin.settings.globalValue('theme'));
+    if (DARK_THEME_IDS.has(themeId)) return 'dark';
+    if (LIGHT_THEME_IDS.has(themeId)) return 'light';
+  } catch (error) {
+    console.warn('excalidraw: could not read the Joplin theme:', error);
+  }
+  return 'auto';
+}
+
+const escapeAttribute = (value: string): string =>
+  value.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+
+const buildDialogHTML = (diagramBody: string, theme: JoplinThemePref): string => {
   return `
 		<form name="main" style="display:none">
-			<input type="hidden" name="excalidraw_diagram_json" id="excalidraw_diagram_json" value='${diagramBody}'>
-			<input type="hidden" name="excalidraw_diagram_svg" id="excalidraw_diagram_svg" value=''>
+			<input type="hidden" name="excalidraw_diagram_json" id="excalidraw_diagram_json" value="${escapeAttribute(diagramBody)}">
+			<input type="hidden" name="excalidraw_diagram_svg" id="excalidraw_diagram_svg" value="">
+			<input type="hidden" name="excalidraw_theme" id="excalidraw_theme" value="${theme}">
 		</form>
 		`
 }
@@ -24,6 +48,7 @@ function diagramMarkdown(diagramId: string) {
 const openDialog = async (svgResourceId: string = null): Promise<string | null> => {
   let diagramBody = "{}";
   const appPath = await joplin.plugins.installationDir();
+  const theme = await joplinThemePref();
 
   const isNewDiagram = (svgResourceId === null);
   if (!isNewDiagram) {
@@ -34,7 +59,7 @@ const openDialog = async (svgResourceId: string = null): Promise<string | null> 
   let dialogs = joplin.views.dialogs;
   let dialogHandle = await dialogs.create(`excalidraw-dialog-${uuidv4()}`);
 
-  let header = buildDialogHTML(diagramBody);
+  let header = buildDialogHTML(diagramBody, theme);
   let iframe = `<iframe id="excalidraw_iframe" style="position:absolute;border:0;width:100%;height:100%;" src="${appPath}/local-excalidraw/index.html" title="Excalidraw frame"></iframe>`
 
   await dialogs.setHtml(dialogHandle, header + iframe);

--- a/src/local-excalidraw/index.html
+++ b/src/local-excalidraw/index.html
@@ -4,7 +4,11 @@
     <title>Excalidraw in browser</title>
     <meta charset="UTF-8" />
     <script>
-      window.EXCALIDRAW_ASSET_PATH = "../";
+      // Excalidraw 0.18 resolves asset URLs with `new URL(path, EXCALIDRAW_ASSET_PATH)`,
+      // which requires an absolute base. A relative "../" throws "Invalid base URL" and
+      // breaks font loading, text editing and SVG export. Resolve the dist/ folder
+      // (which holds fonts/) to an absolute URL at runtime.
+      window.EXCALIDRAW_ASSET_PATH = new URL("..", document.location.href).href;
     </script>
   </head>
 

--- a/src/local-excalidraw/index.ts
+++ b/src/local-excalidraw/index.ts
@@ -2,6 +2,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as ExcalidrawLib from "@excalidraw/excalidraw";
+import "@excalidraw/excalidraw/index.css";
 import "./style.css";
 import svgElementToString from '../util/svgElementToString'
 

--- a/src/local-excalidraw/index.ts
+++ b/src/local-excalidraw/index.ts
@@ -6,53 +6,120 @@ import "@excalidraw/excalidraw/index.css";
 import "./style.css";
 import svgElementToString from '../util/svgElementToString'
 
-let InitialData = {
-  appState: { viewBackgroundColor: "#AFEEEE", currentItemFontFamily: 1 }
+// The dialog hands the existing drawing to this iframe, and reads the result
+// back, through hidden inputs in the parent (dialog) document.
+const parentInput = (id: string): HTMLInputElement | null =>
+  window.parent.document.getElementById(id) as HTMLInputElement | null;
+
+const readInitialData = (): any => {
+  try {
+    return JSON.parse(parentInput('excalidraw_diagram_json')!.value);
+  } catch (error) {
+    console.error("excalidraw: could not parse the initial diagram:", error);
+    return {};
+  }
 };
 
-try {
-  let el:HTMLInputElement = window.parent.document.getElementById('excalidraw_diagram_json') as HTMLInputElement;
-  InitialData = JSON.parse(el.value);
-} catch (d) {
-  console.error("error: ", d)
-}
+const InitialData = readInitialData();
 
 const App = () => {
-  const excalidrawWrapperRef = React.useRef(null);
+  const apiRef = React.useRef<any>(null);
+  const svgTimer = React.useRef<number | null>(null);
+
+  // Serializing to JSON is cheap and synchronous, so we keep the hidden input
+  // up to date on every change.
+  const writeJson = React.useCallback(() => {
+    const api = apiRef.current;
+    const input = parentInput('excalidraw_diagram_json');
+    if (!api || !input) return;
+    input.value = ExcalidrawLib.serializeAsJSON(
+      api.getSceneElements(), api.getAppState(), api.getFiles(), "local",
+    );
+  }, []);
+
+  // Exporting to SVG is async and comparatively expensive.
+  const writeSvg = React.useCallback(async () => {
+    const api = apiRef.current;
+    const input = parentInput('excalidraw_diagram_svg');
+    if (!api || !input) return;
+    const svg = await ExcalidrawLib.exportToSvg({
+      elements: api.getSceneElements(),
+      appState: api.getAppState(),
+      files: api.getFiles(),
+    });
+    input.value = svgElementToString(svg);
+  }, []);
+
+  const cancelScheduledSvg = React.useCallback(() => {
+    if (svgTimer.current !== null) {
+      window.clearTimeout(svgTimer.current);
+      svgTimer.current = null;
+    }
+  }, []);
+
+  // Refresh the SVG in the background while drawing (debounced) so it is never
+  // far out of date. The authoritative export happens on Save, below.
+  const scheduleSvg = React.useCallback(() => {
+    cancelScheduledSvg();
+    svgTimer.current = window.setTimeout(() => {
+      svgTimer.current = null;
+      void writeSvg();
+    }, 500);
+  }, [cancelScheduledSvg, writeSvg]);
+
+  const onChange = React.useCallback(() => {
+    writeJson();
+    scheduleSvg();
+  }, [writeJson, scheduleSvg]);
+
+  // The Joplin dialog reads the hidden inputs the instant Save is clicked, but
+  // exporting the SVG is asynchronous. Intercept that click, finish a final
+  // JSON + SVG export, then replay the click so the dialog closes with current
+  // data. ChangeCanvasBackground/ToggleTheme buttons live inside this iframe,
+  // so matching on the parent "Save" button is unambiguous.
+  React.useEffect(() => {
+    const parentDocument = window.parent.document;
+    let saving = false;
+
+    const onParentClick = (event: MouseEvent) => {
+      if (saving) return;
+      const button = (event.target as HTMLElement | null)?.closest('button');
+      if (button?.textContent?.trim() !== 'Save') return;
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+
+      cancelScheduledSvg();
+      writeJson();
+      void writeSvg().finally(() => {
+        saving = true;
+        button.click();
+        saving = false;
+      });
+    };
+
+    parentDocument.addEventListener('click', onParentClick, true);
+    return () => parentDocument.removeEventListener('click', onParentClick, true);
+  }, [cancelScheduledSvg, writeJson, writeSvg]);
 
   return React.createElement(
     React.Fragment,
     null,
     React.createElement(
       "div",
-      {
-        className: "excalidraw-wrapper",
-        ref: excalidrawWrapperRef,
-      },
+      { className: "excalidraw-wrapper" },
       React.createElement(ExcalidrawLib.Excalidraw, {
         initialData: InitialData,
-        // this function will serialize to JSON and export to SVG on each change
-        // it is very inefficient but there is currently no way to perform these operations only when dialog is about to be closed
-        onChange: async(elements, state) => {
-          const excalidrawJson = ExcalidrawLib.serializeAsJSON(
-            elements,
-            state,
-            {},
-            "local"
-          );
-          (window.parent.document.getElementById('excalidraw_diagram_json') as HTMLInputElement).value = excalidrawJson;
-
-          return ExcalidrawLib.exportToSvg({elements: elements, appState: state, files: null}).then(svgEle => {
-            let svgString = svgElementToString(svgEle);
-            (window.parent.document.getElementById('excalidraw_diagram_svg') as HTMLInputElement).value = svgString;
-          });
-        },
+        excalidrawAPI: (api: any) => { apiRef.current = api; },
+        onChange,
       },
-      React.createElement(ExcalidrawLib.MainMenu, null, React.createElement(ExcalidrawLib.MainMenu.DefaultItems.ChangeCanvasBackground)))
-    )
+        React.createElement(
+          ExcalidrawLib.MainMenu, null,
+          React.createElement(ExcalidrawLib.MainMenu.DefaultItems.ChangeCanvasBackground),
+        ),
+      ),
+    ),
   );
 };
 
-const excalidrawWrapper = document.getElementById("app");
-
-ReactDOM.render(React.createElement(App), excalidrawWrapper);
+ReactDOM.render(React.createElement(App), document.getElementById("app"));

--- a/src/local-excalidraw/index.ts
+++ b/src/local-excalidraw/index.ts
@@ -38,10 +38,14 @@ const detectJoplinTheme = (): Theme => {
   return 'light';
 };
 
-const initialTheme = (): Theme => {
+// Theme for a new drawing: the configured Light/Dark choice, or Joplin's theme.
+const newDrawingTheme = (): Theme => {
   const pref = parentInput('excalidraw_theme')?.value;
   return pref === 'light' || pref === 'dark' ? pref : detectJoplinTheme();
 };
+
+const preserveSavedTheme = (): boolean =>
+  parentInput('excalidraw_preserve_theme')?.value !== 'false';
 
 const readInitialData = (): any => {
   let data: any = {};
@@ -50,12 +54,15 @@ const readInitialData = (): any => {
   } catch (error) {
     console.error("excalidraw: could not parse the initial diagram:", error);
   }
-  // New drawings open in Joplin's theme; existing drawings keep the theme they
-  // were saved with (we persist it ourselves in writeJson, below, because
-  // Excalidraw drops appState.theme when it exports JSON).
+  // Existing drawings reopen with the theme they were saved with (we persist it
+  // in writeJson, since Excalidraw drops appState.theme on export) — unless the
+  // user disabled that, in which case they, like new drawings, use the
+  // configured new-drawing theme.
   data.appState = data.appState ?? {};
-  if (data.appState.theme !== 'light' && data.appState.theme !== 'dark') {
-    data.appState.theme = initialTheme();
+  const saved = data.appState.theme;
+  const keepSaved = preserveSavedTheme() && (saved === 'light' || saved === 'dark');
+  if (!keepSaved) {
+    data.appState.theme = newDrawingTheme();
   }
   return data;
 };

--- a/src/local-excalidraw/index.ts
+++ b/src/local-excalidraw/index.ts
@@ -11,13 +11,53 @@ import svgElementToString from '../util/svgElementToString'
 const parentInput = (id: string): HTMLInputElement | null =>
   window.parent.document.getElementById(id) as HTMLInputElement | null;
 
-const readInitialData = (): any => {
+type Theme = 'light' | 'dark';
+
+// Luminance of a CSS rgb/rgba colour, or null when it carries no real colour
+// (unparseable, or fully transparent).
+const backgroundLuminance = (color: string): number | null => {
+  const match = /rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([0-9.]+))?\)/i.exec(color);
+  if (!match || match[4] === '0') return null;
+  const [r, g, b] = [Number(match[1]), Number(match[2]), Number(match[3])];
+  return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+};
+
+// Used when the plugin couldn't resolve Joplin's theme from settings (the
+// "auto-detect" option, or a custom theme): read the dialog's real colours.
+const detectJoplinTheme = (): Theme => {
   try {
-    return JSON.parse(parentInput('excalidraw_diagram_json')!.value);
+    const parent = window.parent;
+    for (const el of [parent.document.body, parent.document.documentElement]) {
+      const luminance = backgroundLuminance(parent.getComputedStyle(el).backgroundColor);
+      if (luminance !== null) return luminance < 0.5 ? 'dark' : 'light';
+    }
+  } catch (error) {
+    console.warn('excalidraw: could not detect the Joplin theme:', error);
+  }
+  if (window.matchMedia?.('(prefers-color-scheme: dark)').matches) return 'dark';
+  return 'light';
+};
+
+const initialTheme = (): Theme => {
+  const pref = parentInput('excalidraw_theme')?.value;
+  return pref === 'light' || pref === 'dark' ? pref : detectJoplinTheme();
+};
+
+const readInitialData = (): any => {
+  let data: any = {};
+  try {
+    data = JSON.parse(parentInput('excalidraw_diagram_json')!.value);
   } catch (error) {
     console.error("excalidraw: could not parse the initial diagram:", error);
-    return {};
   }
+  // New drawings open in Joplin's theme; existing drawings keep the theme they
+  // were saved with (we persist it ourselves in writeJson, below, because
+  // Excalidraw drops appState.theme when it exports JSON).
+  data.appState = data.appState ?? {};
+  if (data.appState.theme !== 'light' && data.appState.theme !== 'dark') {
+    data.appState.theme = initialTheme();
+  }
+  return data;
 };
 
 const InitialData = readInitialData();
@@ -32,9 +72,14 @@ const App = () => {
     const api = apiRef.current;
     const input = parentInput('excalidraw_diagram_json');
     if (!api || !input) return;
-    input.value = ExcalidrawLib.serializeAsJSON(
+    const json = JSON.parse(ExcalidrawLib.serializeAsJSON(
       api.getSceneElements(), api.getAppState(), api.getFiles(), "local",
-    );
+    ));
+    // Excalidraw omits the theme from exported JSON, so store it ourselves to
+    // reopen the drawing with the same theme next time.
+    json.appState = json.appState ?? {};
+    json.appState.theme = api.getAppState().theme;
+    input.value = JSON.stringify(json);
   }, []);
 
   // Exporting to SVG is async and comparatively expensive.
@@ -42,9 +87,16 @@ const App = () => {
     const api = apiRef.current;
     const input = parentInput('excalidraw_diagram_svg');
     if (!api || !input) return;
+    const appState = api.getAppState();
     const svg = await ExcalidrawLib.exportToSvg({
       elements: api.getSceneElements(),
-      appState: api.getAppState(),
+      appState: {
+        ...appState,
+        exportBackground: true,
+        // Export in the drawing's own theme so the SVG matches what was drawn
+        // (dark drawings get Excalidraw's invert filter on the root <svg>).
+        exportWithDarkMode: appState.theme === 'dark',
+      },
       files: api.getFiles(),
     });
     input.value = svgElementToString(svg);
@@ -115,6 +167,7 @@ const App = () => {
       },
         React.createElement(
           ExcalidrawLib.MainMenu, null,
+          React.createElement(ExcalidrawLib.MainMenu.DefaultItems.ToggleTheme),
           React.createElement(ExcalidrawLib.MainMenu.DefaultItems.ChangeCanvasBackground),
         ),
       ),

--- a/src/local-excalidraw/style.css
+++ b/src/local-excalidraw/style.css
@@ -1,6 +1,13 @@
+html,
+body,
+#app,
+.container {
+    height: 100%;
+    margin: 0;
+  }
+
 .container {
     font-family: sans-serif;
-    text-align: center;
   }
   
   .button-wrapper button {
@@ -16,7 +23,7 @@
   }
   
   .excalidraw-wrapper {
-    height: 700px;
+    height: 100%;
     margin: 0px;
     position: relative;
   }

--- a/vite-local.config.ts
+++ b/vite-local.config.ts
@@ -4,7 +4,13 @@ import { defineConfig } from "vite";
 export default defineConfig({
   root: resolve(__dirname, "src/local-excalidraw"),
   base: './',
+  optimizeDeps: {
+    esbuildOptions: {
+      target: "esnext",
+    },
+  },
   build: {
+    target: "esnext",
     chunkSizeWarningLimit: 3000,
     outDir: resolve(__dirname, "dist/local-excalidraw"),
     rollupOptions: {

--- a/vite-webview.config.ts
+++ b/vite-webview.config.ts
@@ -3,7 +3,13 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   root: resolve(__dirname, "src/webview"),
+  optimizeDeps: {
+    esbuildOptions: {
+      target: "esnext",
+    },
+  },
   build: {
+    target: "esnext",
     chunkSizeWarningLimit: 3000,
     outDir: resolve(__dirname, "dist/webview"),
     rollupOptions: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -174,9 +174,10 @@ const pluginConfig = Object.assign({}, baseConfig, {
 		new CopyPlugin({
 			patterns: [
 				{
-					from: path.resolve(__dirname, "node_modules/@excalidraw/excalidraw/dist/excalidraw-assets"),
-					// correct path is provided via 'window.EXCALIDRAW_ASSET_PATH'
-					to: path.resolve(__dirname, "dist/excalidraw-assets")
+					// Excalidraw 0.18 ships fonts under dist/prod/fonts; the editor iframe
+					// resolves them via 'window.EXCALIDRAW_ASSET_PATH' (set to "../") -> dist/fonts.
+					from: path.resolve(__dirname, "node_modules/@excalidraw/excalidraw/dist/prod/fonts"),
+					to: path.resolve(__dirname, "dist/fonts")
 				}
 			]
     	}),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,15 +2,187 @@
 # yarn lockfile v1
 
 
-"@excalidraw/excalidraw@0.17.2":
-  version "0.17.2"
-  resolved "https://registry.yarnpkg.com/@excalidraw/excalidraw/-/excalidraw-0.17.2.tgz#9a636a1e6bb3c88c5883347d3a7e75e9cce8ab96"
-  integrity sha512-7pqUWD8+mPjDhF4XxG3gw4rvE2JGaLW3Vss5UZfTbITPxAtFaGEc1K081bncitnaYhUwN9ENJE0i87QB3poDwQ==
+"@antfu/install-pkg@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@antfu/install-pkg/-/install-pkg-1.1.0.tgz#78fa036be1a6081b5a77a5cf59f50c7752b6ba26"
+  integrity sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==
+  dependencies:
+    package-manager-detector "^1.3.0"
+    tinyexec "^1.0.1"
+
+"@babel/runtime@^7.13.10":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
+
+"@braintree/sanitize-url@6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz#6110f918d273fe2af8ea1c4398a88774bb9fc12f"
+  integrity sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==
+
+"@braintree/sanitize-url@^7.1.1":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz#ca2035b0fefe956a8676ff0c69af73e605fcd81f"
+  integrity sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==
+
+"@chevrotain/cst-dts-gen@11.0.3":
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz#5e0863cc57dc45e204ccfee6303225d15d9d4783"
+  integrity sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==
+  dependencies:
+    "@chevrotain/gast" "11.0.3"
+    "@chevrotain/types" "11.0.3"
+    lodash-es "4.17.21"
+
+"@chevrotain/gast@11.0.3":
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/@chevrotain/gast/-/gast-11.0.3.tgz#e84d8880323fe8cbe792ef69ce3ffd43a936e818"
+  integrity sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==
+  dependencies:
+    "@chevrotain/types" "11.0.3"
+    lodash-es "4.17.21"
+
+"@chevrotain/regexp-to-ast@11.0.3":
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz#11429a81c74a8e6a829271ce02fc66166d56dcdb"
+  integrity sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==
+
+"@chevrotain/types@11.0.3":
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/@chevrotain/types/-/types-11.0.3.tgz#f8a03914f7b937f594f56eb89312b3b8f1c91848"
+  integrity sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==
+
+"@chevrotain/types@~11.1.1":
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/@chevrotain/types/-/types-11.1.2.tgz#e83a1a2704f0c5e49e7592b214031a0f4a34d7e5"
+  integrity sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==
+
+"@chevrotain/utils@11.0.3":
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/@chevrotain/utils/-/utils-11.0.3.tgz#e39999307b102cff3645ec4f5b3665f5297a2224"
+  integrity sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==
+
+"@excalidraw/excalidraw@0.18.1":
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/@excalidraw/excalidraw/-/excalidraw-0.18.1.tgz#fd6ad752807c814698c5f51dab778845b7e4bba7"
+  integrity sha512-6i5Gt7IDTOH//qa0Z315Ly5iVRhjWpu2whrlQFqkuwrkKUWgRsMk0P5qdE7bpyDpai7jeLeWYkyj1eVAfni1lw==
+  dependencies:
+    "@braintree/sanitize-url" "6.0.2"
+    "@excalidraw/laser-pointer" "1.3.1"
+    "@excalidraw/mermaid-to-excalidraw" "2.2.2"
+    "@excalidraw/random-username" "1.1.0"
+    "@radix-ui/react-popover" "1.1.6"
+    "@radix-ui/react-tabs" "1.0.2"
+    browser-fs-access "0.29.1"
+    canvas-roundrect-polyfill "0.0.1"
+    clsx "1.1.1"
+    cross-env "7.0.3"
+    es6-promise-pool "2.5.0"
+    fractional-indexing "3.2.0"
+    fuzzy "0.1.3"
+    image-blob-reduce "3.0.1"
+    jotai "2.11.0"
+    jotai-scope "0.7.2"
+    lodash.debounce "4.0.8"
+    lodash.throttle "4.1.1"
+    nanoid "3.3.3"
+    open-color "1.9.1"
+    pako "2.0.3"
+    perfect-freehand "1.2.0"
+    pica "7.1.1"
+    png-chunk-text "1.0.0"
+    png-chunks-encode "1.0.0"
+    png-chunks-extract "1.0.0"
+    points-on-curve "1.0.1"
+    pwacompat "2.0.17"
+    roughjs "4.6.4"
+    sass "1.51.0"
+    tunnel-rat "0.1.2"
+
+"@excalidraw/laser-pointer@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@excalidraw/laser-pointer/-/laser-pointer-1.3.1.tgz#7c40836598e8e6ad91f01057883ed8b88fb9266c"
+  integrity sha512-psA1z1N2qeAfsORdXc9JmD2y4CmDwmuMRxnNdJHZexIcPwaNEyIpNcelw+QkL9rz9tosaN9krXuKaRqYpRAR6g==
+
+"@excalidraw/markdown-to-text@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@excalidraw/markdown-to-text/-/markdown-to-text-0.1.2.tgz#1703705e7da608cf478f17bfe96fb295f55a23eb"
+  integrity sha512-1nDXBNAojfi3oSFwJswKREkFm5wrSjqay81QlyRv2pkITG/XYB5v+oChENVBQLcxQwX4IUATWvXM5BcaNhPiIg==
+
+"@excalidraw/mermaid-to-excalidraw@2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@excalidraw/mermaid-to-excalidraw/-/mermaid-to-excalidraw-2.2.2.tgz#ee6b597a0d95b9a76f7ae41ce0e3733a9b96e4a0"
+  integrity sha512-5VKQq5CdRocC82vOIUpQ5ufJOVV9FpBTdHGA+ULqazeIVV+cr299877omQCibsdS3Bpitz2fsnTwnIXEmLVDSg==
+  dependencies:
+    "@excalidraw/markdown-to-text" "0.1.2"
+    "@mermaid-js/parser" "^0.6.3"
+    mermaid "^11.12.1"
+    nanoid "4.0.2"
+
+"@excalidraw/random-username@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@excalidraw/random-username/-/random-username-1.1.0.tgz#6f388d6a9708cf655b8c9c6aa3fa569ee71ecf0f"
+  integrity sha512-nULYsQxkWHnbmHvcs+efMkJ4/9TtvNyFeLyHdeGxW0zHs6P+jYVqcRff9A6Vq9w9JXeDRnRh2VKvTtS19GW2qA==
+
+"@floating-ui/core@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.7.5.tgz#d4af157a03330af5a60e69da7a4692507ada0622"
+  integrity sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==
+  dependencies:
+    "@floating-ui/utils" "^0.2.11"
+
+"@floating-ui/dom@^1.7.6":
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.7.6.tgz#f915bba5abbb177e1f227cacee1b4d0634b187bf"
+  integrity sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==
+  dependencies:
+    "@floating-ui/core" "^1.7.5"
+    "@floating-ui/utils" "^0.2.11"
+
+"@floating-ui/react-dom@^2.0.0":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.8.tgz#5fb5a20d10aafb9505f38c24f38d00c8e1598893"
+  integrity sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==
+  dependencies:
+    "@floating-ui/dom" "^1.7.6"
+
+"@floating-ui/utils@^0.2.11":
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.11.tgz#a269e055e40e2f45873bae9d1a2fdccbd314ea3f"
+  integrity sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==
 
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
+
+"@iconify/types@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@iconify/types/-/types-2.0.0.tgz#ab0e9ea681d6c8a1214f30cd741fe3a20cc57f57"
+  integrity sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==
+
+"@iconify/utils@^3.0.2":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@iconify/utils/-/utils-3.1.3.tgz#71efd68f9ed2ea3c91fd3a01c0032f70a87027b7"
+  integrity sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==
+  dependencies:
+    "@antfu/install-pkg" "^1.1.0"
+    "@iconify/types" "^2.0.0"
+    import-meta-resolve "^4.2.0"
+
+"@mermaid-js/parser@^0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@mermaid-js/parser/-/parser-0.6.3.tgz#3ce92dad2c5d696d29e11e21109c66a7886c824e"
+  integrity sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==
+  dependencies:
+    langium "3.3.1"
+
+"@mermaid-js/parser@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@mermaid-js/parser/-/parser-1.1.1.tgz#30f3ab68d816912e43f245a72a0d4081bf69d966"
+  integrity sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==
+  dependencies:
+    "@chevrotain/types" "~11.1.1"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -49,6 +221,510 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@radix-ui/primitive@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.0.0.tgz#e1d8ef30b10ea10e69c76e896f608d9276352253"
+  integrity sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/primitive@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.1.tgz#fc169732d755c7fbad33ba8d0cd7fd10c90dc8e3"
+  integrity sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==
+
+"@radix-ui/react-arrow@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.2.tgz#30c0d574d7bb10eed55cd7007b92d38b03c6b2ab"
+  integrity sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.2"
+
+"@radix-ui/react-collection@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.0.1.tgz#259506f97c6703b36291826768d3c1337edd1de5"
+  integrity sha512-uuiFbs+YCKjn3X1DTSx9G7BHApu4GHbi3kgiwsnFUbOKCrwejAJv4eE4Vc8C0Oaxt9T0aV4ox0WCOdx+39Xo+g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.1"
+    "@radix-ui/react-slot" "1.0.1"
+
+"@radix-ui/react-compose-refs@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz#37595b1f16ec7f228d698590e78eeed18ff218ae"
+  integrity sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-compose-refs@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz#6f766faa975f8738269ebb8a23bad4f5a8d2faec"
+  integrity sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==
+
+"@radix-ui/react-context@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.0.0.tgz#f38e30c5859a9fb5e9aa9a9da452ee3ed9e0aee0"
+  integrity sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-context@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.1.tgz#82074aa83a472353bb22e86f11bcbd1c61c4c71a"
+  integrity sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==
+
+"@radix-ui/react-direction@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.0.0.tgz#a2e0b552352459ecf96342c79949dd833c1e6e45"
+  integrity sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-dismissable-layer@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.5.tgz#96dde2be078c694a621e55e047406c58cd5fe774"
+  integrity sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.2"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-escape-keydown" "1.1.0"
+
+"@radix-ui/react-focus-guards@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz#8635edd346304f8b42cae86b05912b61aef27afe"
+  integrity sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==
+
+"@radix-ui/react-focus-scope@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.2.tgz#c0a4519cd95c772606a82fc5b96226cd7fdd2602"
+  integrity sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.2"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+
+"@radix-ui/react-id@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.0.0.tgz#8d43224910741870a45a8c9d092f25887bb6d11e"
+  integrity sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+
+"@radix-ui/react-id@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.0.tgz#de47339656594ad722eb87f94a6b25f9cffae0ed"
+  integrity sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
+"@radix-ui/react-popover@1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popover/-/react-popover-1.1.6.tgz#699634dbc7899429f657bb590d71fb3ca0904087"
+  integrity sha512-NQouW0x4/GnkFJ/pRqsIS3rM/k97VzKnVb2jB7Gq7VEGPy5g7uNV1ykySFt7eWSp3i2uSGFwaJcvIRJBAHmmFg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-dismissable-layer" "1.1.5"
+    "@radix-ui/react-focus-guards" "1.1.1"
+    "@radix-ui/react-focus-scope" "1.1.2"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-popper" "1.2.2"
+    "@radix-ui/react-portal" "1.1.4"
+    "@radix-ui/react-presence" "1.1.2"
+    "@radix-ui/react-primitive" "2.0.2"
+    "@radix-ui/react-slot" "1.1.2"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.6.3"
+
+"@radix-ui/react-popper@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.2.2.tgz#d2e1ee5a9b24419c5936a1b7f6f472b7b412b029"
+  integrity sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.1.2"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.2"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+    "@radix-ui/react-use-rect" "1.1.0"
+    "@radix-ui/react-use-size" "1.1.0"
+    "@radix-ui/rect" "1.1.0"
+
+"@radix-ui/react-portal@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.4.tgz#ff5401ff63c8a825c46eea96d3aef66074b8c0c8"
+  integrity sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.2"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
+"@radix-ui/react-presence@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.0.0.tgz#814fe46df11f9a468808a6010e3f3ca7e0b2e84a"
+  integrity sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+
+"@radix-ui/react-presence@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.2.tgz#bb764ed8a9118b7ec4512da5ece306ded8703cdc"
+  integrity sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
+"@radix-ui/react-primitive@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.1.tgz#c1ebcce283dd2f02e4fbefdaa49d1cb13dbc990a"
+  integrity sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-slot" "1.0.1"
+
+"@radix-ui/react-primitive@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz#ac8b7854d87b0d7af388d058268d9a7eb64ca8ef"
+  integrity sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==
+  dependencies:
+    "@radix-ui/react-slot" "1.1.2"
+
+"@radix-ui/react-roving-focus@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.2.tgz#d8ac2e3b8006697bdfc2b0eb06bef7e15b6245de"
+  integrity sha512-HLK+CqD/8pN6GfJm3U+cqpqhSKYAWiOJDe+A+8MfxBnOue39QEeMa43csUn2CXCHQT0/mewh1LrrG4tfkM9DMA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-collection" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-direction" "1.0.0"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.1"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
+
+"@radix-ui/react-slot@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.1.tgz#e7868c669c974d649070e9ecbec0b367ee0b4d81"
+  integrity sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+
+"@radix-ui/react-slot@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.1.2.tgz#daffff7b2bfe99ade63b5168407680b93c00e1c6"
+  integrity sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
+
+"@radix-ui/react-tabs@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.0.2.tgz#8f5ec73ca41b151a413bdd6e00553408ff34ce07"
+  integrity sha512-gOUwh+HbjCuL0UCo8kZ+kdUEG8QtpdO4sMQduJ34ZEz0r4922g9REOBM+vIsfwtGxSug4Yb1msJMJYN2Bk8TpQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-direction" "1.0.0"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-presence" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.1"
+    "@radix-ui/react-roving-focus" "1.0.2"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
+
+"@radix-ui/react-use-callback-ref@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz#9e7b8b6b4946fe3cbe8f748c82a2cce54e7b6a90"
+  integrity sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-callback-ref@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz#bce938ca413675bc937944b0d01ef6f4a6dc5bf1"
+  integrity sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==
+
+"@radix-ui/react-use-controllable-state@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz#a64deaafbbc52d5d407afaa22d493d687c538b7f"
+  integrity sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+
+"@radix-ui/react-use-controllable-state@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz#1321446857bb786917df54c0d4d084877aab04b0"
+  integrity sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==
+  dependencies:
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+
+"@radix-ui/react-use-escape-keydown@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz#31a5b87c3b726504b74e05dac1edce7437b98754"
+  integrity sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==
+  dependencies:
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+
+"@radix-ui/react-use-layout-effect@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz#2fc19e97223a81de64cd3ba1dc42ceffd82374dc"
+  integrity sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-layout-effect@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz#3c2c8ce04827b26a39e442ff4888d9212268bd27"
+  integrity sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==
+
+"@radix-ui/react-use-rect@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz#13b25b913bd3e3987cc9b073a1a164bb1cf47b88"
+  integrity sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==
+  dependencies:
+    "@radix-ui/rect" "1.1.0"
+
+"@radix-ui/react-use-size@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz#b4dba7fbd3882ee09e8d2a44a3eed3a7e555246b"
+  integrity sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
+"@radix-ui/rect@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.0.tgz#f817d1d3265ac5415dadc67edab30ae196696438"
+  integrity sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==
+
+"@types/d3-array@*":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.2.2.tgz#e02151464d02d4a1b44646d0fcdb93faf88fde8c"
+  integrity sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==
+
+"@types/d3-axis@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-axis/-/d3-axis-3.0.6.tgz#e760e5765b8188b1defa32bc8bb6062f81e4c795"
+  integrity sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-brush@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-brush/-/d3-brush-3.0.6.tgz#c2f4362b045d472e1b186cdbec329ba52bdaee6c"
+  integrity sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-chord@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-chord/-/d3-chord-3.0.6.tgz#1706ca40cf7ea59a0add8f4456efff8f8775793d"
+  integrity sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==
+
+"@types/d3-color@*":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.3.tgz#368c961a18de721da8200e80bf3943fb53136af2"
+  integrity sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==
+
+"@types/d3-contour@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-contour/-/d3-contour-3.0.6.tgz#9ada3fa9c4d00e3a5093fed0356c7ab929604231"
+  integrity sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/geojson" "*"
+
+"@types/d3-delaunay@*":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz#185c1a80cc807fdda2a3fe960f7c11c4a27952e1"
+  integrity sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==
+
+"@types/d3-dispatch@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz#ef004d8a128046cfce434d17182f834e44ef95b2"
+  integrity sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==
+
+"@types/d3-drag@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-drag/-/d3-drag-3.0.7.tgz#b13aba8b2442b4068c9a9e6d1d82f8bcea77fc02"
+  integrity sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-dsv@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-dsv/-/d3-dsv-3.0.7.tgz#0a351f996dc99b37f4fa58b492c2d1c04e3dac17"
+  integrity sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==
+
+"@types/d3-ease@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-ease/-/d3-ease-3.0.2.tgz#e28db1bfbfa617076f7770dd1d9a48eaa3b6c51b"
+  integrity sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==
+
+"@types/d3-fetch@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-fetch/-/d3-fetch-3.0.7.tgz#c04a2b4f23181aa376f30af0283dbc7b3b569980"
+  integrity sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==
+  dependencies:
+    "@types/d3-dsv" "*"
+
+"@types/d3-force@*":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@types/d3-force/-/d3-force-3.0.10.tgz#6dc8fc6e1f35704f3b057090beeeb7ac674bff1a"
+  integrity sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==
+
+"@types/d3-format@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-3.0.4.tgz#b1e4465644ddb3fdf3a263febb240a6cd616de90"
+  integrity sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==
+
+"@types/d3-geo@*":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-geo/-/d3-geo-3.1.0.tgz#b9e56a079449174f0a2c8684a9a4df3f60522440"
+  integrity sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==
+  dependencies:
+    "@types/geojson" "*"
+
+"@types/d3-hierarchy@*":
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz#6023fb3b2d463229f2d680f9ac4b47466f71f17b"
+  integrity sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==
+
+"@types/d3-interpolate@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz#412b90e84870285f2ff8a846c6eb60344f12a41c"
+  integrity sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==
+  dependencies:
+    "@types/d3-color" "*"
+
+"@types/d3-path@*":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-3.1.1.tgz#f632b380c3aca1dba8e34aa049bcd6a4af23df8a"
+  integrity sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==
+
+"@types/d3-polygon@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-polygon/-/d3-polygon-3.0.2.tgz#dfae54a6d35d19e76ac9565bcb32a8e54693189c"
+  integrity sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==
+
+"@types/d3-quadtree@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz#d4740b0fe35b1c58b66e1488f4e7ed02952f570f"
+  integrity sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==
+
+"@types/d3-random@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-random/-/d3-random-3.0.3.tgz#ed995c71ecb15e0cd31e22d9d5d23942e3300cfb"
+  integrity sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==
+
+"@types/d3-scale-chromatic@*":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#dc6d4f9a98376f18ea50bad6c39537f1b5463c39"
+  integrity sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==
+
+"@types/d3-scale@*":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.9.tgz#57a2f707242e6fe1de81ad7bfcccaaf606179afb"
+  integrity sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-selection@*":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-3.0.11.tgz#bd7a45fc0a8c3167a631675e61bc2ca2b058d4a3"
+  integrity sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==
+
+"@types/d3-shape@*":
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.1.8.tgz#d1516cc508753be06852cd06758e3bb54a22b0e3"
+  integrity sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==
+  dependencies:
+    "@types/d3-path" "*"
+
+"@types/d3-time-format@*":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-time-format/-/d3-time-format-4.0.3.tgz#d6bc1e6b6a7db69cccfbbdd4c34b70632d9e9db2"
+  integrity sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==
+
+"@types/d3-time@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8000eb33edd444e1323f"
+  integrity sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
+
+"@types/d3-timer@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-3.0.2.tgz#70bbda77dc23aa727413e22e214afa3f0e852f70"
+  integrity sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==
+
+"@types/d3-transition@*":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-transition/-/d3-transition-3.0.9.tgz#1136bc57e9ddb3c390dccc9b5ff3b7d2b8d94706"
+  integrity sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-zoom@*":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@types/d3-zoom/-/d3-zoom-3.0.8.tgz#dccb32d1c56b1e1c6e0f1180d994896f038bc40b"
+  integrity sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==
+  dependencies:
+    "@types/d3-interpolate" "*"
+    "@types/d3-selection" "*"
+
+"@types/d3@^7.4.3":
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/@types/d3/-/d3-7.4.3.tgz#d4550a85d08f4978faf0a4c36b848c61eaac07e2"
+  integrity sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/d3-axis" "*"
+    "@types/d3-brush" "*"
+    "@types/d3-chord" "*"
+    "@types/d3-color" "*"
+    "@types/d3-contour" "*"
+    "@types/d3-delaunay" "*"
+    "@types/d3-dispatch" "*"
+    "@types/d3-drag" "*"
+    "@types/d3-dsv" "*"
+    "@types/d3-ease" "*"
+    "@types/d3-fetch" "*"
+    "@types/d3-force" "*"
+    "@types/d3-format" "*"
+    "@types/d3-geo" "*"
+    "@types/d3-hierarchy" "*"
+    "@types/d3-interpolate" "*"
+    "@types/d3-path" "*"
+    "@types/d3-polygon" "*"
+    "@types/d3-quadtree" "*"
+    "@types/d3-random" "*"
+    "@types/d3-scale" "*"
+    "@types/d3-scale-chromatic" "*"
+    "@types/d3-selection" "*"
+    "@types/d3-shape" "*"
+    "@types/d3-time" "*"
+    "@types/d3-time-format" "*"
+    "@types/d3-timer" "*"
+    "@types/d3-transition" "*"
+    "@types/d3-zoom" "*"
+
+"@types/geojson@*":
+  version "7946.0.16"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.16.tgz#8ebe53d69efada7044454e3305c19017d97ced2a"
+  integrity sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
+
 "@types/json-schema@^7.0.8":
   version "7.0.11"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz"
@@ -76,6 +752,19 @@
   version "14.18.63"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
   integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
+
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
+"@upsetjs/venn.js@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@upsetjs/venn.js/-/venn.js-2.0.0.tgz#3be192038cdda927aa4f8b22ab51af82abf47f34"
+  integrity sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==
+  optionalDependencies:
+    d3-selection "^3.0.0"
+    d3-transition "^3.0.1"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -310,6 +999,13 @@ aproba@^1.1.1:
   resolved "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
+aria-hidden@^1.2.4:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.6.tgz#73051c9b088114c795b1ea414e9c0fff874ffc1a"
+  integrity sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==
+  dependencies:
+    tslib "^2.0.0"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz"
@@ -469,6 +1165,11 @@ brorand@^1.0.1, brorand@^1.1.0:
   resolved "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
   integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
 
+browser-fs-access@0.29.1:
+  version "0.29.1"
+  resolved "https://registry.yarnpkg.com/browser-fs-access/-/browser-fs-access-0.29.1.tgz#8a9794c73cf86b9aec74201829999c597128379c"
+  integrity sha512-LSvVX5e21LRrXqVMhqtAwj5xPgDb+fXAIH80NsnCQ9xuZPs2xWsOREi24RKgZa1XOiQRbcmVrv87+ulOKsgjxw==
+
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
   resolved "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz"
@@ -619,6 +1320,11 @@ camelcase@^5.0.0:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
+canvas-roundrect-polyfill@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/canvas-roundrect-polyfill/-/canvas-roundrect-polyfill-0.0.1.tgz#70bf107ebe2037f26d839d7f809a26f4a95f5696"
+  integrity sha512-yWq+R3U3jE+coOeEb3a3GgE2j/0MMiDKM/QpLb6h9ihf5fGY9UXtvK9o4vNqjWXoZz7/3EaSVU3IX53TvFFUOw==
+
 chalk@^2.3.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
@@ -635,6 +1341,40 @@ chalk@^4.1.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chevrotain-allstar@~0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz#b7412755f5d83cc139ab65810cdb00d8db40e6ca"
+  integrity sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==
+  dependencies:
+    lodash-es "^4.17.21"
+
+chevrotain@~11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/chevrotain/-/chevrotain-11.0.3.tgz#88ffc1fb4b5739c715807eaeedbbf200e202fc1b"
+  integrity sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==
+  dependencies:
+    "@chevrotain/cst-dts-gen" "11.0.3"
+    "@chevrotain/gast" "11.0.3"
+    "@chevrotain/regexp-to-ast" "11.0.3"
+    "@chevrotain/types" "11.0.3"
+    "@chevrotain/utils" "11.0.3"
+    lodash-es "4.17.21"
+
+"chokidar@>=3.0.0 <4.0.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 chokidar@^2.1.8:
   version "2.1.8"
@@ -726,6 +1466,11 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+clsx@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz"
@@ -758,10 +1503,20 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+commander@7:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
 commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commander@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -837,6 +1592,25 @@ core-util-is@~1.0.0:
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
+cose-base@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cose-base/-/cose-base-1.0.3.tgz#650334b41b869578a543358b80cda7e0abe0a60a"
+  integrity sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==
+  dependencies:
+    layout-base "^1.0.0"
+
+cose-base@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cose-base/-/cose-base-2.2.0.tgz#1c395c35b6e10bb83f9769ca8b817d614add5c01"
+  integrity sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==
+  dependencies:
+    layout-base "^2.0.0"
+
+crc-32@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-0.3.0.tgz#6a3d3687f5baec41f7e9b99fe1953a2e5d19775e"
+  integrity sha512-kucVIjOmMc1f0tv53BJ/5WIX+MGLcKuoBhnGqQrgKJNqLByb/sVMWfW/Aw6hw0jgcqjJ2pi9E5y32zOIpaUlsA==
+
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz"
@@ -868,6 +1642,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz"
@@ -878,6 +1659,15 @@ cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.1:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -905,6 +1695,309 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz"
   integrity sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==
+
+cytoscape-cose-bilkent@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz#762fa121df9930ffeb51a495d87917c570ac209b"
+  integrity sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==
+  dependencies:
+    cose-base "^1.0.0"
+
+cytoscape-fcose@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz#e4d6f6490df4fab58ae9cea9e5c3ab8d7472f471"
+  integrity sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==
+  dependencies:
+    cose-base "^2.2.0"
+
+cytoscape@^3.33.1:
+  version "3.34.0"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.34.0.tgz#5fbe2eb1cf76b070a8ecd5647c35f65aa097c9c6"
+  integrity sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==
+
+"d3-array@1 - 2":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.12.1.tgz#e20b41aafcdffdf5d50928004ececf815a465e81"
+  integrity sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==
+  dependencies:
+    internmap "^1.0.0"
+
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@^3.2.0:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
+  integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
+  dependencies:
+    internmap "1 - 2"
+
+d3-axis@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-3.0.0.tgz#c42a4a13e8131d637b745fc2973824cfeaf93322"
+  integrity sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
+
+d3-brush@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-3.0.0.tgz#6f767c4ed8dcb79de7ede3e1c0f89e63ef64d31c"
+  integrity sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "3"
+    d3-transition "3"
+
+d3-chord@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-3.0.1.tgz#d156d61f485fce8327e6abf339cb41d8cbba6966"
+  integrity sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==
+  dependencies:
+    d3-path "1 - 3"
+
+"d3-color@1 - 3", d3-color@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
+d3-contour@4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-4.0.2.tgz#bb92063bc8c5663acb2422f99c73cbb6c6ae3bcc"
+  integrity sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==
+  dependencies:
+    d3-array "^3.2.0"
+
+d3-delaunay@6:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz#98169038733a0a5babbeda55054f795bb9e4a58b"
+  integrity sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==
+  dependencies:
+    delaunator "5"
+
+"d3-dispatch@1 - 3", d3-dispatch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
+  integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
+
+"d3-drag@2 - 3", d3-drag@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
+  integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-selection "3"
+
+"d3-dsv@1 - 3", d3-dsv@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-3.0.1.tgz#c63af978f4d6a0d084a52a673922be2160789b73"
+  integrity sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
+  dependencies:
+    commander "7"
+    iconv-lite "0.6"
+    rw "1"
+
+"d3-ease@1 - 3", d3-ease@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
+d3-fetch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-3.0.1.tgz#83141bff9856a0edb5e38de89cdcfe63d0a60a22"
+  integrity sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==
+  dependencies:
+    d3-dsv "1 - 3"
+
+d3-force@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-3.0.0.tgz#3e2ba1a61e70888fe3d9194e30d6d14eece155c4"
+  integrity sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-quadtree "1 - 3"
+    d3-timer "1 - 3"
+
+"d3-format@1 - 3", d3-format@3:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.2.tgz#01fdb46b58beb1f55b10b42ad70b6e344d5eb2ae"
+  integrity sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==
+
+d3-geo@3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.1.1.tgz#6027cf51246f9b2ebd64f99e01dc7c3364033a4d"
+  integrity sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==
+  dependencies:
+    d3-array "2.5.0 - 3"
+
+d3-hierarchy@3:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz#b01cd42c1eed3d46db77a5966cf726f8c09160c6"
+  integrity sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==
+
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
+d3-path@1:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
+  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+"d3-path@1 - 3", d3-path@3, d3-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.1.0.tgz#22df939032fb5a71ae8b1800d61ddb7851c42526"
+  integrity sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
+
+d3-polygon@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-3.0.1.tgz#0b45d3dd1c48a29c8e057e6135693ec80bf16398"
+  integrity sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==
+
+"d3-quadtree@1 - 3", d3-quadtree@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz#6dca3e8be2b393c9a9d514dabbd80a92deef1a4f"
+  integrity sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
+
+d3-random@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-3.0.1.tgz#d4926378d333d9c0bfd1e6fa0194d30aebaa20f4"
+  integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
+
+d3-sankey@^0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/d3-sankey/-/d3-sankey-0.12.3.tgz#b3c268627bd72e5d80336e8de6acbfec9d15d01d"
+  integrity sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==
+  dependencies:
+    d3-array "1 - 2"
+    d3-shape "^1.2.0"
+
+d3-scale-chromatic@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#34c39da298b23c20e02f1a4b239bd0f22e7f1314"
+  integrity sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==
+  dependencies:
+    d3-color "1 - 3"
+    d3-interpolate "1 - 3"
+
+d3-scale@4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+"d3-selection@2 - 3", d3-selection@3, d3-selection@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
+
+d3-shape@3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.2.0.tgz#a1a839cbd9ba45f28674c69d7f855bcf91dfc6a5"
+  integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
+  dependencies:
+    d3-path "^3.1.0"
+
+d3-shape@^1.2.0:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+  dependencies:
+    d3-path "1"
+
+"d3-time-format@2 - 4", d3-time-format@4:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
+
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
+  integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
+  dependencies:
+    d3-array "2 - 3"
+
+"d3-timer@1 - 3", d3-timer@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
+
+"d3-transition@2 - 3", d3-transition@3, d3-transition@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
+  integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
+  dependencies:
+    d3-color "1 - 3"
+    d3-dispatch "1 - 3"
+    d3-ease "1 - 3"
+    d3-interpolate "1 - 3"
+    d3-timer "1 - 3"
+
+d3-zoom@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
+  integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "2 - 3"
+    d3-transition "2 - 3"
+
+d3@^7.9.0:
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-7.9.0.tgz#579e7acb3d749caf8860bd1741ae8d371070cd5d"
+  integrity sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==
+  dependencies:
+    d3-array "3"
+    d3-axis "3"
+    d3-brush "3"
+    d3-chord "3"
+    d3-color "3"
+    d3-contour "4"
+    d3-delaunay "6"
+    d3-dispatch "3"
+    d3-drag "3"
+    d3-dsv "3"
+    d3-ease "3"
+    d3-fetch "3"
+    d3-force "3"
+    d3-format "3"
+    d3-geo "3"
+    d3-hierarchy "3"
+    d3-interpolate "3"
+    d3-path "3"
+    d3-polygon "3"
+    d3-quadtree "3"
+    d3-random "3"
+    d3-scale "4"
+    d3-scale-chromatic "3"
+    d3-selection "3"
+    d3-shape "3"
+    d3-time "3"
+    d3-time-format "4"
+    d3-timer "3"
+    d3-transition "3"
+    d3-zoom "3"
+
+dagre-d3-es@7.0.14:
+  version "7.0.14"
+  resolved "https://registry.yarnpkg.com/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz#1272276e26457cf3b97dac569f8f0531ec33c377"
+  integrity sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==
+  dependencies:
+    d3 "^7.9.0"
+    lodash-es "^4.17.21"
+
+dayjs@^1.11.19:
+  version "1.11.21"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.21.tgz#57f87562e62de76f3c704bd2b8d522fc33068eb2"
+  integrity sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -945,6 +2038,13 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+delaunator@5:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-5.1.0.tgz#d13271fbf3aff6753f9ea6e235557f20901046ea"
+  integrity sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==
+  dependencies:
+    robust-predicates "^3.0.2"
+
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz"
@@ -957,6 +2057,11 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz"
   integrity sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==
+
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -978,6 +2083,13 @@ domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz"
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
+
+dompurify@^3.3.1:
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.8.tgz#6c54f8c207160e7f83fcb7f4fd05a82ac36b1cdc"
+  integrity sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
@@ -1039,6 +2151,16 @@ errno@^0.1.3, errno@~0.1.7:
   integrity sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==
   dependencies:
     prr "~1.0.1"
+
+es-toolkit@^1.45.1:
+  version "1.47.0"
+  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.47.0.tgz#846778dac47af951f9917363ec5a3b94beeb8ddc"
+  integrity sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==
+
+es6-promise-pool@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/es6-promise-pool/-/es6-promise-pool-2.5.0.tgz#147c612b36b47f105027f9d2bf54a598a99d9ccb"
+  integrity sha512-VHErXfzR/6r/+yyzPKeBvO0lgjfC5cbDCQWjWwMZWSb6YU39TGIl51OUmCfWCq4ylMdJSB8zkz2vIuIeIxXApA==
 
 esbuild-android-arm64@0.13.15:
   version "0.13.15"
@@ -1356,6 +2478,11 @@ for-in@^1.0.2:
   resolved "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
   integrity sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==
 
+fractional-indexing@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fractional-indexing/-/fractional-indexing-3.2.0.tgz#1193e63d54ff4e0cbe0c79a9ed6cfbab25d91628"
+  integrity sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz"
@@ -1421,10 +2548,20 @@ function-bind@^1.1.1:
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+fuzzy@0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/fuzzy/-/fuzzy-0.1.3.tgz#4c76ec2ff0ac1a36a9dccf9a00df8623078d4ed8"
+  integrity sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==
+
 get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -1506,6 +2643,11 @@ globby@^11.0.1:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+glur@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/glur/-/glur-1.1.2.tgz#f20ea36db103bfc292343921f1f91e83c3467689"
+  integrity sha512-l+8esYHTKOx2G/Aao4lEQ0bnHWg4fWtJbVoZZT9Knxi01pB8C80BR85nONLFwkkQoFRCmXY+BUcGZN3yZ2QsRA==
+
 goober@^2.1.10:
   version "2.1.16"
   resolved "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz"
@@ -1515,6 +2657,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.2.10"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
+hachure-fill@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/hachure-fill/-/hachure-fill-0.5.2.tgz#d19bc4cc8750a5962b47fb1300557a85fcf934cc"
+  integrity sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -1602,6 +2749,13 @@ https-browserify@^1.0.0:
   resolved "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz"
   integrity sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==
 
+iconv-lite@0.6:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
@@ -1617,6 +2771,18 @@ ignore@^5.2.0:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
+image-blob-reduce@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/image-blob-reduce/-/image-blob-reduce-3.0.1.tgz#812be7655a552031635799ae64e846b106f7a489"
+  integrity sha512-/VmmWgIryG/wcn4TVrV7cC4mlfUC/oyiKIfSg5eVM3Ten/c1c34RJhMYKCWTnoSMHSqXLt3tsrBR4Q2HInvN+Q==
+  dependencies:
+    pica "^7.1.0"
+
+immutable@^4.0.0:
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.8.tgz#02d183c7727fb2bb1d5d0380da0d779dce9296a7"
+  integrity sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==
+
 import-local@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz"
@@ -1624,6 +2790,11 @@ import-local@^2.0.0:
   dependencies:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
+
+import-meta-resolve@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz#08cb85b5bd37ecc8eb1e0f670dc2767002d43734"
+  integrity sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -1667,6 +2838,16 @@ ini@^1.3.4, ini@^1.3.5:
   version "1.3.8"
   resolved "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
+
+internmap@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
+  integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
 
 interpret@^1.4.0:
   version "1.4.0"
@@ -1837,6 +3018,16 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
+jotai-scope@0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/jotai-scope/-/jotai-scope-0.7.2.tgz#3e9ec5b743bd9f36b08b32cf5151786049bfcce7"
+  integrity sha512-Gwed97f3dDObrO43++2lRcgOqw4O2sdr4JCjP/7eHK1oPACDJ7xKHGScpJX9XaflU+KBHXF+VhwECnzcaQiShg==
+
+jotai@2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.11.0.tgz#923f8351e0b2d721036af892c0ae25625049d120"
+  integrity sha512-zKfoBBD1uDw3rljwHkt0fWuja1B76R7CjznuBO+mSX6jpsO1EBeWNRKpeaQho9yPI/pvCv4recGfgOXGxwPZvQ==
+
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -1873,6 +3064,18 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+katex@^0.16.25:
+  version "0.16.47"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.16.47.tgz#0a13a42c2deb4f74e61f162d440b9165a548030f"
+  integrity sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==
+  dependencies:
+    commander "^8.3.0"
+
+khroma@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/khroma/-/khroma-2.1.0.tgz#45f2ce94ce231a437cf5b63c2e886e6eb42bbbb1"
+  integrity sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
@@ -1896,6 +3099,27 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+langium@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/langium/-/langium-3.3.1.tgz#da745a40d5ad8ee565090fed52eaee643be4e591"
+  integrity sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==
+  dependencies:
+    chevrotain "~11.0.3"
+    chevrotain-allstar "~0.3.0"
+    vscode-languageserver "~9.0.1"
+    vscode-languageserver-textdocument "~1.0.11"
+    vscode-uri "~3.0.8"
+
+layout-base@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/layout-base/-/layout-base-1.0.2.tgz#1291e296883c322a9dd4c5dd82063721b53e26e2"
+  integrity sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==
+
+layout-base@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/layout-base/-/layout-base-2.0.1.tgz#d0337913586c90f9c2c075292069f5c2da5dd285"
+  integrity sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==
 
 loader-runner@^2.4.0:
   version "2.4.0"
@@ -1934,6 +3158,26 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash-es@4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
+lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
+
+lodash.debounce@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
+
+lodash.throttle@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
 loose-envify@^1.1.0:
   version "1.4.0"
@@ -1983,6 +3227,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+marked@^16.3.0:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-16.4.2.tgz#4959a64be6c486f0db7467ead7ce288de54290a3"
+  integrity sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz"
@@ -2012,6 +3261,33 @@ merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+mermaid@^11.12.1:
+  version "11.15.0"
+  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-11.15.0.tgz#b485c13ea5e1e74f3328c4bb00427bda87fa1c1e"
+  integrity sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==
+  dependencies:
+    "@braintree/sanitize-url" "^7.1.1"
+    "@iconify/utils" "^3.0.2"
+    "@mermaid-js/parser" "^1.1.1"
+    "@types/d3" "^7.4.3"
+    "@upsetjs/venn.js" "^2.0.0"
+    cytoscape "^3.33.1"
+    cytoscape-cose-bilkent "^4.1.0"
+    cytoscape-fcose "^2.2.0"
+    d3 "^7.9.0"
+    d3-sankey "^0.12.3"
+    dagre-d3-es "7.0.14"
+    dayjs "^1.11.19"
+    dompurify "^3.3.1"
+    es-toolkit "^1.45.1"
+    katex "^0.16.25"
+    khroma "^2.1.0"
+    marked "^16.3.0"
+    roughjs "^4.6.6"
+    stylis "^4.3.6"
+    ts-dedent "^2.2.0"
+    uuid "^11.1.0 || ^12 || ^13 || ^14.0.0"
 
 micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
@@ -2159,10 +3435,28 @@ ms@2.0.0:
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
+multimath@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/multimath/-/multimath-2.0.0.tgz#0d37acf67c328f30e3d8c6b0d3209e6082710302"
+  integrity sha512-toRx66cAMJ+Ccz7pMIg38xSIrtnbozk0dchXezwQDMgQmbGpfxjtv68H+L00iFL8hxDaVjrmwAFSb3I6bg8Q2g==
+  dependencies:
+    glur "^1.1.2"
+    object-assign "^4.1.1"
+
 nan@^2.12.1:
   version "2.22.0"
   resolved "https://registry.npmmirror.com/nan/-/nan-2.22.0.tgz#31bc433fc33213c97bad36404bb68063de604de3"
   integrity sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==
+
+nanoid@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
+  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
+
+nanoid@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.2.tgz#140b3c5003959adbebf521c170f282c5e7f9fb9e"
+  integrity sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==
 
 nanoid@^3.3.4:
   version "3.3.4"
@@ -2277,6 +3571,11 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+open-color@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/open-color/-/open-color-1.9.1.tgz#a6e6328f60eff7aa60e3e8fcfa50f53ff3eece35"
+  integrity sha512-vCseG/EQ6/RcvxhUcGJiHViOgrtz4x0XbZepXvKik66TMGkvbmjeJrKFyBEx6daG5rNyyd14zYXhz0hZVwQFOw==
+
 os-browserify@^0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz"
@@ -2322,6 +3621,16 @@ p-try@^2.0.0:
   resolved "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+package-manager-detector@^1.3.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/package-manager-detector/-/package-manager-detector-1.6.0.tgz#70d0cf0aa02c877eeaf66c4d984ede0be9130734"
+  integrity sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==
+
+pako@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.3.tgz#cdf475e31b678565251406de9e759196a0ea7a43"
+  integrity sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==
+
 pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz"
@@ -2362,6 +3671,11 @@ path-browserify@0.0.1:
   resolved "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz"
   integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
 
+path-data-parser@0.1.0, path-data-parser@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/path-data-parser/-/path-data-parser-0.1.0.tgz#8f5ba5cc70fc7becb3dcefaea08e2659aba60b8c"
+  integrity sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==
+
 path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz"
@@ -2387,6 +3701,11 @@ path-key@^2.0.1:
   resolved "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
   integrity sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==
 
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
 path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
@@ -2407,6 +3726,22 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+perfect-freehand@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/perfect-freehand/-/perfect-freehand-1.2.0.tgz#706a0f854544f6175772440c51d3b0563eb3988a"
+  integrity sha512-h/0ikF1M3phW7CwpZ5MMvKnfpHficWoOEyr//KVNTxV4F6deRK1eYMtHyBKEAKFK0aXIEUK9oBvlF6PNXMDsAw==
+
+pica@7.1.1, pica@^7.1.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/pica/-/pica-7.1.1.tgz#c68b42f5cfa6cc26eaec5cfa10cc0a5299ef3b7a"
+  integrity sha512-WY73tMvNzXWEld2LicT9Y260L43isrZ85tPuqRyvtkljSDLmnNFQmZICt4xUJMVulmcc6L9O7jbBrtx3DOz/YQ==
+  dependencies:
+    glur "^1.1.2"
+    inherits "^2.0.3"
+    multimath "^2.0.0"
+    object-assign "^4.1.1"
+    webworkify "^1.5.0"
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -2436,6 +3771,44 @@ pkg-dir@^4.1.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+png-chunk-text@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/png-chunk-text/-/png-chunk-text-1.0.0.tgz#1c6006d8e34ba471d38e1c9c54b3f53e1085e18f"
+  integrity sha512-DEROKU3SkkLGWNMzru3xPVgxyd48UGuMSZvioErCure6yhOc/pRH2ZV+SEn7nmaf7WNf3NdIpH+UTrRdKyq9Lw==
+
+png-chunks-encode@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/png-chunks-encode/-/png-chunks-encode-1.0.0.tgz#d9ea5e35caeeed782658c1ab7bafa7a5edb1a878"
+  integrity sha512-J1jcHgbQRsIIgx5wxW9UmCymV3wwn4qCCJl6KYgEU/yHCh/L2Mwq/nMOkRPtmV79TLxRZj5w3tH69pvygFkDqA==
+  dependencies:
+    crc-32 "^0.3.0"
+    sliced "^1.0.1"
+
+png-chunks-extract@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/png-chunks-extract/-/png-chunks-extract-1.0.0.tgz#fad4a905e66652197351c65e35b92c64311e472d"
+  integrity sha512-ZiVwF5EJ0DNZyzAqld8BP1qyJBaGOFaq9zl579qfbkcmOwWLLO4I9L8i2O4j3HkI6/35i0nKG2n+dZplxiT89Q==
+  dependencies:
+    crc-32 "^0.3.0"
+
+points-on-curve@0.2.0, points-on-curve@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/points-on-curve/-/points-on-curve-0.2.0.tgz#7dbb98c43791859434284761330fa893cb81b4d1"
+  integrity sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==
+
+points-on-curve@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/points-on-curve/-/points-on-curve-1.0.1.tgz#03fcdc08e48e3bfdc7e8bd1d7ccd4d5f11e132c6"
+  integrity sha512-3nmX4/LIiyuwGLwuUrfhTlDeQFlAhi7lyK/zcRNGhalwapDWgAGR82bUpmn2mA03vII3fvNCG8jAONzKXwpxAg==
+
+points-on-path@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/points-on-path/-/points-on-path-0.2.1.tgz#553202b5424c53bed37135b318858eacff85dd52"
+  integrity sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==
+  dependencies:
+    path-data-parser "0.1.0"
+    points-on-curve "0.2.0"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -2523,6 +3896,11 @@ punycode@^2.1.0:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+pwacompat@2.0.17:
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/pwacompat/-/pwacompat-2.0.17.tgz#707959ff97f239bf1fe7b260b63aeea416a15eab"
+  integrity sha512-6Du7IZdIy7cHiv7AhtDy4X2QRM8IAD5DII69mt5qWibC2d15ZU8DmBG1WdZKekG11cChSu4zkSUGPF9sweOl6w==
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
@@ -2553,9 +3931,9 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-react-dom@^17.0.1:
+react-dom@^17.0.2:
   version "17.0.2"
-  resolved "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
   integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
   dependencies:
     loose-envify "^1.1.0"
@@ -2569,9 +3947,36 @@ react-hot-toast@^2.4.1:
   dependencies:
     goober "^2.1.10"
 
-react@^17.0.1:
+react-remove-scroll-bar@^2.3.7:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz#99c20f908ee467b385b68a3469b4a3e750012223"
+  integrity sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==
+  dependencies:
+    react-style-singleton "^2.2.2"
+    tslib "^2.0.0"
+
+react-remove-scroll@^2.6.3:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz#6442da56791117661978ae99cd29be9026fecca0"
+  integrity sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==
+  dependencies:
+    react-remove-scroll-bar "^2.3.7"
+    react-style-singleton "^2.2.3"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.3"
+    use-sidecar "^1.1.3"
+
+react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.3.tgz#4265608be69a4d70cfe3047f2c6c88b2c3ace388"
+  integrity sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==
+  dependencies:
+    get-nonce "^1.0.0"
+    tslib "^2.0.0"
+
+react@^17.0.2:
   version "17.0.2"
-  resolved "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
@@ -2714,12 +4119,37 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+robust-predicates@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.3.tgz#1099061b3349e2c5abec6c2ab0acd440d24d4062"
+  integrity sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==
+
 rollup@^2.57.0:
   version "2.79.1"
   resolved "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz"
   integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
   optionalDependencies:
     fsevents "~2.3.2"
+
+roughjs@4.6.4:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/roughjs/-/roughjs-4.6.4.tgz#b6f39b44645854a6e0a4a28b078368701eb7f939"
+  integrity sha512-s6EZ0BntezkFYMf/9mGn7M8XGIoaav9QQBCnJROWB3brUWQ683Q2LbRD/hq0Z3bAJ/9NVpU/5LpiTWvQMyLDhw==
+  dependencies:
+    hachure-fill "^0.5.2"
+    path-data-parser "^0.1.0"
+    points-on-curve "^0.2.0"
+    points-on-path "^0.2.1"
+
+roughjs@^4.6.6:
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/roughjs/-/roughjs-4.6.6.tgz#1059f49a5e0c80dee541a005b20cc322b222158b"
+  integrity sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==
+  dependencies:
+    hachure-fill "^0.5.2"
+    path-data-parser "^0.1.0"
+    points-on-curve "^0.2.0"
+    points-on-path "^0.2.1"
 
 run-parallel@^1.1.9:
   version "1.2.0"
@@ -2734,6 +4164,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha512-ntymy489o0/QQplUDnpYAYUsO50K9SBrIVaKCWDOJzYJts0f9WH9RFJkyagebkw5+y1oi00R7ynNW/d12GBumg==
   dependencies:
     aproba "^1.1.1"
+
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
@@ -2752,10 +4187,19 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-safer-buffer@^2.1.0:
+"safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sass@1.51.0:
+  version "1.51.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.51.0.tgz#25ea36cf819581fe1fe8329e8c3a4eaaf70d2845"
+  integrity sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+    immutable "^4.0.0"
+    source-map-js ">=0.6.2 <2.0.0"
 
 scheduler@^0.20.2:
   version "0.20.2"
@@ -2849,15 +4293,32 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
   integrity sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==
 
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+sliced@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sliced/-/sliced-1.0.1.tgz#0b3a662b5d04c3177b1926bea82b03f837a2ef41"
+  integrity sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -2893,6 +4354,11 @@ source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+
+"source-map-js@>=0.6.2 <2.0.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
 source-map-js@^1.0.2:
   version "1.0.2"
@@ -3040,6 +4506,11 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
+stylis@^4.3.6:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.4.0.tgz#c5846c9345f4bfc51bd0cbd7ca35a0744f485a5d"
+  integrity sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
@@ -3122,6 +4593,11 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+tinyexec@^1.0.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.2.4.tgz#ae45bb2edebda94c70f4ea897e0f1243e470db71"
+  integrity sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==
+
 to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
@@ -3159,6 +4635,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+ts-dedent@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
+  integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
+
 ts-loader@^7.0.5:
   version "7.0.5"
   resolved "https://registry.npmjs.org/ts-loader/-/ts-loader-7.0.5.tgz"
@@ -3170,10 +4651,22 @@ ts-loader@^7.0.5:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
+tslib@^2.0.0, tslib@^2.1.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
   integrity sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==
+
+tunnel-rat@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tunnel-rat/-/tunnel-rat-0.1.2.tgz#1717efbc474ea2d8aa05a91622457a6e201c0aeb"
+  integrity sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==
+  dependencies:
+    zustand "^4.3.2"
 
 typedarray@^0.0.6:
   version "0.0.6"
@@ -3247,6 +4740,26 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-callback-ref@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.3.tgz#98d9fab067075841c5b2c6852090d5d0feabe2bf"
+  integrity sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==
+  dependencies:
+    tslib "^2.0.0"
+
+use-sidecar@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.3.tgz#10e7fd897d130b896e2c546c63a5e8233d00efdb"
+  integrity sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
+
+use-sync-external-store@^1.2.2:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.npmjs.org/use/-/use-3.1.1.tgz"
@@ -3270,6 +4783,11 @@ util@^0.11.0:
   integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
   dependencies:
     inherits "2.0.3"
+
+"uuid@^11.1.0 || ^12 || ^13 || ^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 uuid@^9.0.0:
   version "9.0.0"
@@ -3297,6 +4815,41 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vscode-jsonrpc@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz#f43dfa35fb51e763d17cd94dcca0c9458f35abf9"
+  integrity sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==
+
+vscode-languageserver-protocol@3.17.5:
+  version "3.17.5"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz#864a8b8f390835572f4e13bd9f8313d0e3ac4bea"
+  integrity sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==
+  dependencies:
+    vscode-jsonrpc "8.2.0"
+    vscode-languageserver-types "3.17.5"
+
+vscode-languageserver-textdocument@~1.0.11:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz#457ee04271ab38998a093c68c2342f53f6e4a631"
+  integrity sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==
+
+vscode-languageserver-types@3.17.5:
+  version "3.17.5"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz#3273676f0cf2eab40b3f44d085acbb7f08a39d8a"
+  integrity sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==
+
+vscode-languageserver@~9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz#500aef82097eb94df90d008678b0b6b5f474015b"
+  integrity sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==
+  dependencies:
+    vscode-languageserver-protocol "3.17.5"
+
+vscode-uri@~3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.8.tgz#1770938d3e72588659a172d0fd4642780083ff9f"
+  integrity sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==
 
 watchpack-chokidar2@^2.0.1:
   version "2.0.1"
@@ -3370,6 +4923,11 @@ webpack@^4.43.0:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
+webworkify@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/webworkify/-/webworkify-1.5.0.tgz#734ad87a774de6ebdd546e1d3e027da5b8f4a42c"
+  integrity sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==
+
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz"
@@ -3379,6 +4937,13 @@ which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 
@@ -3483,3 +5048,10 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zustand@^4.3.2:
+  version "4.5.7"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.5.7.tgz#7d6bb2026a142415dd8be8891d7870e6dbe65f55"
+  integrity sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==
+  dependencies:
+    use-sync-external-store "^1.2.2"


### PR DESCRIPTION
## Summary

Upgrades bundled Excalidraw to 0.18.1, adds light/dark theme support and editing from the editor, and fixes issues that surfaced with 0.18.

### Fixes
- **Text tool & SVG fonts:** 0.18 resolves asset URLs with `new URL(path, EXCALIDRAW_ASSET_PATH)`, which requires an absolute base — the previous relative `"../"` threw `Invalid base URL` inside `loadSceneFonts`/`startTextEditing`, which broke text input and font loading. The asset path is resolved to an absolute URL at runtime; the hand-drawn font now embeds in exported SVGs.
- **Reliable save:** the SVG export is flushed before the dialog closes, so the stored preview always matches the drawing.

### Features
- **Light/dark theme:** new drawings follow Joplin's current theme (configurable: Follow Joplin / Light / Dark); existing drawings reopen with their saved theme; the exported SVG is rendered in that theme. A *Settings → Excalidraw* section is included, with a "Keep each drawing's saved theme" toggle.
- **Edit from the editor:** an "Edit Excalidraw drawing" command in a *Tools → Excalidraw* submenu and in the editor right-click menu (shown only when the cursor's line holds a drawing). A small CodeMirror 6 content script provides current-line detection and refreshes the edited image in place.

### Notes
- React stays on 17 (within 0.18's peer range).
- Tested on Joplin desktop (Linux): text/font, theme on create + edit, SVG export, and editing existing drawings.
- Version bump left to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
